### PR TITLE
Update path creation and implemented possibility save data after removing PV

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You may also want to change the PROVISIONER_NAME above from ``fuseim.pri/ifs`` t
 
 **Step 5: Deploying your storage class**
 
-***Paraments:***
+***paraments:***
 
 | Name | Description |  Default |
 |------|-------------|:--------:|

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ spec:
 
 You may also want to change the PROVISIONER_NAME above from ``fuseim.pri/ifs`` to something more descriptive like ``nfs-storage``, but if you do remember to also change the PROVISIONER_NAME in the storage class definition below:
 
+**Step 5: Deploying your storage class**
+
+***Paraments:***
+
+| Name | Description |  Default |
+|------|-------------|:--------:|
+| onDelete | If it exists and has a delete value, delete the directory, if it exists and has a retain value, save the directory. | will be archived with name on the share: `archived-+volume.Name` |
+| archiveOnDelete | If it exists and has a false value, delete the directory. if `onDelete` exists will be ignored. | will be archived with name on the share: `archived-+volume.Name` |
+| archiveOnDelete | If it exists and has a false value, delete the directory. if `onDelete` exists will be ignored. | will be archived with name on the share: `archived-+volume.Name` |
+| pathPattern | Specifies a template for creating a directory path via PVC metadata's such as labels, annotations, name or namespace. To specify metadata use `${.PVC.}`: `${PVC.namespace}`|  n/a |
+
 This is `deploy/class.yaml` which defines the NFS-Client's Kubernetes Storage Class:
 
 ```yaml
@@ -116,11 +127,11 @@ metadata:
   name: managed-nfs-storage
 provisioner: fuseim.pri/ifs # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
-  archiveOnDelete: "false" # When set to "false" your PVs will not be archived
-                           # by the provisioner upon deletion of the PVC.
+  pathPattern: "${.PVC.namespace}/${.PVC.annotations.nfs.io/storage-path}" # waits for nfs.io/storage-path annotation, if not specified will accept as empty string.
+  onDelete: delete   
 ```
 
-**Step 5: Finally, test your environment!**
+**Step 6: Finally, test your environment!**
 
 Now we'll test your NFS provisioner.
 
@@ -138,7 +149,7 @@ kubectl delete -f deploy/test-pod.yaml -f deploy/test-claim.yaml
 
 Now check the folder has been deleted.
 
-**Step 6: Deploying your own PersistentVolumeClaims**. To deploy your own PVC, make sure that you have the correct `storage-class` as indicated by your `deploy/class.yaml` file.
+**Step 7: Deploying your own PersistentVolumeClaims**. To deploy your own PVC, make sure that you have the correct `storage-class` as indicated by your `deploy/class.yaml` file.
 
 For example:
 
@@ -149,6 +160,7 @@ metadata:
   name: test-claim
   annotations:
     volume.beta.kubernetes.io/storage-class: "managed-nfs-storage"
+    nfs.io/storage-path: "test-path" # not required, depending on whether this annotation was shown in the storage class description
 spec:
   accessModes:
     - ReadWriteMany

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You may also want to change the PROVISIONER_NAME above from ``fuseim.pri/ifs`` t
 
 **Step 5: Deploying your storage class**
 
-***paraments:***
+***Parameters:***
 
 | Name | Description |  Default |
 |------|-------------|:--------:|

--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ You may also want to change the PROVISIONER_NAME above from ``fuseim.pri/ifs`` t
 | Name | Description |  Default |
 |------|-------------|:--------:|
 | onDelete | If it exists and has a delete value, delete the directory, if it exists and has a retain value, save the directory. | will be archived with name on the share: `archived-+volume.Name` |
-| archiveOnDelete | If it exists and has a false value, delete the directory. if `onDelete` exists will be ignored. | will be archived with name on the share: `archived-+volume.Name` |
-| archiveOnDelete | If it exists and has a false value, delete the directory. if `onDelete` exists will be ignored. | will be archived with name on the share: `archived-+volume.Name` |
+| archiveOnDelete | If it exists and has a false value, delete the directory. if `onDelete` exists, `archiveOnDelete` will be ignored. | will be archived with name on the share: `archived-+volume.Name` |
 | pathPattern | Specifies a template for creating a directory path via PVC metadata's such as labels, annotations, name or namespace. To specify metadata use `${.PVC.}`: `${PVC.namespace}`|  n/a |
 
 This is `deploy/class.yaml` which defines the NFS-Client's Kubernetes Storage Class:

--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -53,15 +53,15 @@ type pvcMetadata struct {
 	annotations map[string]string
 }
 
+var pattern = regexp.MustCompile(`{pvc\.((labels|annotations)\.(.*?)|.*?)}`)
+
 func (meta *pvcMetadata) stringParser(str string) string {
-	pattern := regexp.MustCompile(`{pvc\.((labels|annotations)\.(.*?)|.*?)}`)
 	result := pattern.FindAllStringSubmatch(str, -1)
 	for _, r := range result {
 		switch r[2] {
 		case "labels":
 			str = strings.Replace(str, r[0], meta.labels[r[3]], -1)
 		case "annotations":
-			fmt.Println(r[0], r[3], meta.annotations[r[3]])
 			str = strings.Replace(str, r[0], meta.annotations[r[3]], -1)
 		default:
 			str = strings.Replace(str, r[0], meta.data[r[1]], -1)

--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -168,14 +168,12 @@ func (p *nfsProvisioner) Delete(volume *v1.PersistentVolume) error {
 	// Otherwise, archive it.
 	archiveOnDelete, exists := storageClass.Parameters["archiveOnDelete"]
 	if exists {
-		if exists {
-			archiveBool, err := strconv.ParseBool(archiveOnDelete)
-			if err != nil {
-				return err
-			}
-			if !archiveBool {
-				return os.RemoveAll(oldPath)
-			}
+		archiveBool, err := strconv.ParseBool(archiveOnDelete)
+		if err != nil {
+			return err
+		}
+		if !archiveBool {
+			return os.RemoveAll(oldPath)
 		}
 	}
 


### PR DESCRIPTION
Hello,

This PR resolved issue #6 .

In the scope of this PR was added the ability to use metadate (name, namespace, labels, annotations) PVC field for dynamical creation the pvPath and possibility saving data on nfs-storage after deletion PV.

Example:

StorageClass:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: nfs
provisioner: nfs.lgi.io/dynamic-provisioner
parameters:
  onDelete: "retain"
  pathPattern: "${.PVC.namespace}/${.PVC.annotations.nfs.lgi.io/storage-path}"
mountOptions:
  - lookupcache=pos
```

PersistentVolumeClaim:
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: hollow-producer
  namespace: lab5a
  annotations:
    volume.beta.kubernetes.io/storage-class: "nfs"
    nfs.lgi.io/storage-path: "hollow-export" # path which will created: /lab5a/hollow-export
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 500Gi
```