### PR TITLE
Add endpoints rule for CusterRole

### DIFF
--- a/deploy/objects/clusterrole.yaml
+++ b/deploy/objects/clusterrole.yaml
@@ -15,3 +15,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -22,6 +22,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Hi, love this NFS provisioner is a thing, it's perfect especially for development. Although after following the setup in your README I encountered the following problem after creating the [test-claim.yaml](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/deploy/test-claim.yaml):
```
root@node2 # kubectl describe pvc
Name:          test-claim
Namespace:     default
StorageClass:  managed-nfs-storage
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   nfs.io/storage-path: test-path
               volume.beta.kubernetes.io/storage-provisioner: nfs-provisioner
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type    Reason                Age                From                         Message
  ----    ------                ----               ----                         -------
  Normal  ExternalProvisioning  0s (x19 over 4m21s)  persistentvolume-controller  waiting for a volume to be created, either by external provisioner "nfs-provisioner" or manually created by system administrator
```

By searching for a similar issue I found this [solution](https://github.com/kubernetes-retired/external-storage/issues/754#issuecomment-449519952), where the author suggests missing rule for endpoints.

Applying his changes the StorageClass successfully creates PVs and the test case (including `test-pod.yaml` and `test-claim.yaml`) passes.

Please have a look at my changes and have in mind I'm a k8s beginner and not sure whether all of those verbs are required.

Thanks.