### PR TITLE
Add GitHub multi-architecture pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=quay.io/external_storage/nfs-subdir-external-provisioner
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            if [[ $VERSION =~ ^v([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
+               MAJOR="${BASH_REMATCH[1]}"
+               MINOR="${BASH_REMATCH[2]}"
+               PATCH="${BASH_REMATCH[3]}"
+
+               TAGS="${DOCKER_IMAGE}:latest"
+               TAGS="${TAGS},${DOCKER_IMAGE}:${MAJOR}"
+               TAGS="${TAGS},${DOCKER_IMAGE}:${MAJOR}.${MINOR}"
+               TAGS="${TAGS},${DOCKER_IMAGE}:${MAJOR}.${MINOR}.${PATCH}"
+            else
+               TAGS="${DOCKER_IMAGE}:${VERSION}"
+            fi
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=edge
+            fi
+            TAGS="${DOCKER_IMAGE}:${VERSION}"
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            TAGS="${DOCKER_IMAGE}:pr-${{ github.event.number }}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to the container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.multiarch
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          build-args: |
+            APP_FOLDER=/go/src/github.com/kubernetes-sigs/nfs-subdir-external-provisioner
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
-            APP_FOLDER="/go/src/github.com/$GITHUB_REPOSITORY"
+            APP_FOLDER=/go/src/github.com/${{ github.repository }}
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,8 @@ name: ci
 
 on:
   push:
-    branches:
-      - '**'
     tags:
-      - 'v*.*.*'
-  pull_request:
+      - 'gh-v*.*.*'
 
 jobs:
   docker:
@@ -21,7 +18,7 @@ jobs:
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
-            if [[ $VERSION =~ ^v([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
+            if [[ $VERSION =~ ^gh-v([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
                MAJOR="${BASH_REMATCH[1]}"
                MINOR="${BASH_REMATCH[2]}"
                PATCH="${BASH_REMATCH[3]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=quay.io/external_storage/nfs-subdir-external-provisioner
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
             if [[ $VERSION =~ ^v([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
@@ -27,21 +26,21 @@ jobs:
                MINOR="${BASH_REMATCH[2]}"
                PATCH="${BASH_REMATCH[3]}"
 
-               TAGS="${DOCKER_IMAGE}:latest"
-               TAGS="${TAGS},${DOCKER_IMAGE}:${MAJOR}"
-               TAGS="${TAGS},${DOCKER_IMAGE}:${MAJOR}.${MINOR}"
-               TAGS="${TAGS},${DOCKER_IMAGE}:${MAJOR}.${MINOR}.${PATCH}"
+               TAGS="${{ secrets.DOCKER_IMAGE }}:latest"
+               TAGS="${TAGS},${{ secrets.DOCKER_IMAGE }}:${MAJOR}"
+               TAGS="${TAGS},${{ secrets.DOCKER_IMAGE }}:${MAJOR}.${MINOR}"
+               TAGS="${TAGS},${{ secrets.DOCKER_IMAGE }}:${MAJOR}.${MINOR}.${PATCH}"
             else
-               TAGS="${DOCKER_IMAGE}:${VERSION}"
+               TAGS="${{ secrets.DOCKER_IMAGE }}:${VERSION}"
             fi
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
             if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
               VERSION=edge
             fi
-            TAGS="${DOCKER_IMAGE}:${VERSION}"
+            TAGS="${{ secrets.DOCKER_IMAGE }}:${VERSION}"
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            TAGS="${DOCKER_IMAGE}:pr-${{ github.event.number }}"
+            TAGS="${{ secrets.DOCKER_IMAGE }}:pr-${{ github.event.number }}"
           fi
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -70,7 +69,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
-            APP_FOLDER=/go/src/github.com/kubernetes-sigs/nfs-subdir-external-provisioner
+            APP_FOLDER="/go/src/github.com/$GITHUB_REPOSITORY"
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,0 +1,21 @@
+FROM --platform=$BUILDPLATFORM golang:1.14 as build-env
+
+# xx wraps go to automatically configure $GOOS, $GOARCH, and $GOARM
+# based on TARGETPLATFORM provided by Docker.
+COPY --from=tonistiigi/xx:golang-1.0.0 / /
+
+ARG APP_FOLDER
+
+ADD . ${APP_FOLDER}
+WORKDIR ${APP_FOLDER}
+
+# Compile independent executable using go wrapper from xx:golang
+ARG TARGETPLATFORM
+RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /bin/main ./cmd/nfs-subdir-external-provisioner
+
+FROM --platform=$TARGETPLATFORM alpine:3.12
+
+RUN apk update --no-cache && apk add ca-certificates
+COPY --from=build-env /bin/main /app/main
+
+ENTRYPOINT ["/app/main"]

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ spec:
 
 # Build and publish with GitHub Actions
 
-In a forked repository you can use GitHub Actions pipeline defined in [.github/workflows/release.yml](.github/workflows/release.yml). The pipeline builds Docker images for `linux/amd64`, `linux/arm64`, and `linux/arm/v7` platforms and publishes them using a multi-arch manifest attaching tags according to next rules:
-* For master branch it uses `:edge` tag and pushes images to the registry.
+In a forked repository you can use GitHub Actions pipeline defined in [.github/workflows/release.yml](.github/workflows/release.yml). The pipeline builds Docker images for `linux/amd64`, `linux/arm64`, and `linux/arm/v7` platforms and publishes them using a multi-arch manifest attaching tags according to the next rules:
+* For the master branch, it uses `:edge` tag and pushes images to the registry.
 * For any other branch except master, it uses the branch name as the tag name replacing `/`s with `-`s, and pushes to the registry.
 * For any tag matching patter `v{major}.{minor}.{patch}` it creates several tags: `latest`, `{major}`, `{major}:{minor}`, `{major}:{minor}:{patch}` and pushes to the registry. For any other tag, it uses the tag's name as the image tag and pushes too.
-* For pull requests it uses ephemeral `:pr-{github.event.number}` tags, builds the images but doesn't push to the registry.
+* For pull requests, it uses ephemeral `:pr-{github.event.number}` tags, builds the images but doesn't push to the registry.
 
 The pipeline adds several labels:
 * `org.opencontainers.image.title=${{ github.event.repository.name }}`
@@ -198,5 +198,5 @@ The pipeline adds several labels:
 * `org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}`
 
 **Important:**
-* The pipeline performs the docker login command using `REGISTRY_USERNAME` and `REGISTRY_TOKEN` secrets which have to be provided.
-* You also need to replace `quay.io/external_storage/nfs-subdir-external-provisioner` with your image name.
+* The pipeline performs the docker login command using `REGISTRY_USERNAME` and `REGISTRY_TOKEN` secrets, which have to be provided.
+* You also need to provide the `DOCKER_IMAGE` secret specifying your Docker image name, e.g., `quay.io/[username]/nfs-subdir-external-provisioner`.

--- a/README.md
+++ b/README.md
@@ -179,3 +179,24 @@ spec:
     requests:
       storage: 1Mi
 ```
+
+# Build and publish with GitHub Actions
+
+In a forked repository you can use GitHub Actions pipeline defined in [.github/workflows/release.yml](.github/workflows/release.yml). The pipeline builds Docker images for `linux/amd64`, `linux/arm64`, and `linux/arm/v7` platforms and publishes them using a multi-arch manifest attaching tags according to next rules:
+* For master branch it uses `:edge` tag and pushes images to the registry.
+* For any other branch except master, it uses the branch name as the tag name replacing `/`s with `-`s, and pushes to the registry.
+* For any tag matching patter `v{major}.{minor}.{patch}` it creates several tags: `latest`, `{major}`, `{major}:{minor}`, `{major}:{minor}:{patch}` and pushes to the registry. For any other tag, it uses the tag's name as the image tag and pushes too.
+* For pull requests it uses ephemeral `:pr-{github.event.number}` tags, builds the images but doesn't push to the registry.
+
+The pipeline adds several labels:
+* `org.opencontainers.image.title=${{ github.event.repository.name }}`
+* `org.opencontainers.image.description=${{ github.event.repository.description }}`
+* `org.opencontainers.image.url=${{ github.event.repository.html_url }}`
+* `org.opencontainers.image.source=${{ github.event.repository.clone_url }}`
+* `org.opencontainers.image.created=${{ steps.prep.outputs.created }}`
+* `org.opencontainers.image.revision=${{ github.sha }}`
+* `org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}`
+
+**Important:**
+* The pipeline performs the docker login command using `REGISTRY_USERNAME` and `REGISTRY_TOKEN` secrets which have to be provided.
+* You also need to replace `quay.io/external_storage/nfs-subdir-external-provisioner` with your image name.

--- a/README.md
+++ b/README.md
@@ -182,11 +182,7 @@ spec:
 
 # Build and publish with GitHub Actions
 
-In a forked repository you can use GitHub Actions pipeline defined in [.github/workflows/release.yml](.github/workflows/release.yml). The pipeline builds Docker images for `linux/amd64`, `linux/arm64`, and `linux/arm/v7` platforms and publishes them using a multi-arch manifest attaching tags according to the next rules:
-* For the master branch, it uses `:edge` tag and pushes images to the registry.
-* For any other branch except master, it uses the branch name as the tag name replacing `/`s with `-`s, and pushes to the registry.
-* For any tag matching patter `v{major}.{minor}.{patch}` it creates several tags: `latest`, `{major}`, `{major}:{minor}`, `{major}:{minor}:{patch}` and pushes to the registry. For any other tag, it uses the tag's name as the image tag and pushes too.
-* For pull requests, it uses ephemeral `:pr-{github.event.number}` tags, builds the images but doesn't push to the registry.
+In a forked repository you can use GitHub Actions pipeline defined in [.github/workflows/release.yml](.github/workflows/release.yml). The pipeline builds Docker images for `linux/amd64`, `linux/arm64`, and `linux/arm/v7` platforms and publishes them using a multi-arch manifest. The pipeline is triggered when you add a tag like `gh-v{major}.{minor}.{patch}` to your commit and push it to GitHub. The tag is used for generating Docker image tags: `latest`, `{major}`, `{major}:{minor}`, `{major}:{minor}:{patch}`.
 
 The pipeline adds several labels:
 * `org.opencontainers.image.title=${{ github.event.repository.name }}`


### PR DESCRIPTION
This change introduces a GitHub Workflow based pipeline. The pipeline builds Docker images for `linux/amd64`, `linux/arm64`, and `linux/arm/v7` platforms and publishes them using a multi-arch manifest under `quay.io/external_storage/nfs-subdir-external-provisioner` name attaching tags according to next rules:
1. For master branch uses `:edge` tag and pushes images to the registry.
2. For any other branch except master, uses the branch name as the tag name replacing `/`s with `-`s, and pushes to the registry.
3. For any tag matching patter `v{major}.{minor}.{patch}` creates several tags: `latest`, `{major}`, `{major}:{minor}`, `{major}:{minor}:{patch}` and pushes to the registry. For any other tag, it uses the tag's name as the image tag and pushes too. 
4. For pull requests it uses ephemeral `:pr-{github.event.number}` tags, builds the images but **doesn't push to the registry**.

This PR replaces specialized Dockerfiles (resided in `docker/arm` and `docker/x86_64`) with a generic one which is used for building Images targeting different platforms.

The pipeline adds several labels:
* org.opencontainers.image.title=${{ github.event.repository.name }}
* org.opencontainers.image.description=${{ github.event.repository.description }}
* org.opencontainers.image.url=${{ github.event.repository.html_url }}
* org.opencontainers.image.source=${{ github.event.repository.clone_url }}
* org.opencontainers.image.created=${{ steps.prep.outputs.created }}
* org.opencontainers.image.revision=${{ github.sha }}
* org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

**Important:**
The pipeline performs the `docker login` command using  `REGISTRY_USERNAME` and `REGISTRY_TOKEN` secrets which have to be provided.