### PR TITLE
Enable mountOptions from StorageClass to PersistentVolume

### DIFF
--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -121,7 +121,7 @@ func (p *nfsProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: *options.StorageClass.ReclaimPolicy,
 			AccessModes:                   options.PVC.Spec.AccessModes,
-			// MountOptions:                  options.MountOptions,
+			MountOptions:                  options.StorageClass.MountOptions,
 			Capacity: v1.ResourceList{
 				v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
 			},


### PR DESCRIPTION
StorageClass supports MountOptions (PersistentVolumeSpec.MountOptions) which can be later used in provisioner when creating the PersistentVolume.
This is very helpful for users that want to apply mount options on their NFS mounts like `vers`, `rsize`, `wsize` and more.

Related to question: #24 