### PR TITLE
Update examples and build updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v4.0.0
+# Unreleased
 - Remove redundant field in the rbac.yaml (https://github.com/kubernetes-retired/external-storage/pull/970)
 - Use `kubernetes-sigs/sig-storage-lib-external-provisioner` instead of `incubator/external-storage/lib` (https://github.com/kubernetes-retired/external-storage/pull/1026)
 - Fill in rbac.yaml with ServiceAccount manifest (https://github.com/kubernetes-retired/external-storage/pull/1060, https://github.com/kubernetes-retired/external-storage/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Make nfs-client ARM deployment consistent with regular deployment (https://github.com/kubernetes-retired/external-storage/pull/1090)
 - Update Deployment apiVersion (from `extensions/v1beta1` to `apps/v1`) and added selector field (https://github.com/kubernetes-retired/external-storage/pull/1230/, https://github.com/kubernetes-retired/external-storage/pull/1231/, https://github.com/kubernetes-retired/external-storage/pull/1283/, https://github.com/kubernetes-retired/external-storage/pull/1294/)
 - Fix namespace in deployments (https://github.com/kubernetes-retired/external-storage/pull/1087, https://github.com/kubernetes-retired/external-storage/pull/1279)
+- Update path creation and implemented possibility save data after removing PV (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/7/)
+- Support for running controller outside of cluster (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/9)
+- Add a flag to disable leader election (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/22)
+- Switched to kubernetes `v1.18.0` to be compatible with `>=1.20` selfLink removal (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/26/)
+- Enable mountOptions from StorageClass to PersistentVolume (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/28)
 
 # v3.1.0
 - README Clarifications and minor formatting improvements (https://github.com/kubernetes-retired/external-storage/pull/938/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # v4.0.0
 - Remove redundant field in the rbac.yaml (https://github.com/kubernetes-retired/external-storage/pull/970)
 - Fixing documentation to be correct for both `kubectl` and `oc` (https://github.com/kubernetes-retired/external-storage/pull/969)
-- Point nfs-client users to Helm and split up yamls (https://github.com/kubernetes-retired/external-storage/pull/995)
+- Point users to Helm and split up yamls (https://github.com/kubernetes-retired/external-storage/pull/995)
 - Use `kubernetes-sigs/sig-storage-lib-external-provisioner` instaed of `incubator/external-storage/lib` (https://github.com/kubernetes-retired/external-storage/pull/1026)
 - Fill in rbac.yaml with ServiceAccount manifest (https://github.com/kubernetes-retired/external-storage/pull/1060, https://github.com/kubernetes-retired/external-storage/pull/1179)
 - Fix some typos in README (https://github.com/kubernetes-retired/external-storage/pull/1054)
-- Make nfs-client ARM deployment consistent with regular deployment (https://github.com/kubernetes-retired/external-storage/pull/1090)
+- Make ARM deployment consistent with regular deployment (https://github.com/kubernetes-retired/external-storage/pull/1090)
 - Update Deployment apiVersion (from `extensions/v1beta1` to `apps/v1`) and added selector field (https://github.com/kubernetes-retired/external-storage/pull/1230/, https://github.com/kubernetes-retired/external-storage/pull/1231/, https://github.com/kubernetes-retired/external-storage/pull/1283/, https://github.com/kubernetes-retired/external-storage/pull/1294/)
 - Fix namespace in deployments (https://github.com/kubernetes-retired/external-storage/pull/1087, https://github.com/kubernetes-retired/external-storage/pull/1279)
 - Update path creation and implemented possibility save data after removing PV (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/7/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 # v4.0.0
 - Remove redundant field in the rbac.yaml (https://github.com/kubernetes-retired/external-storage/pull/970)
-- Fixing documentation to be correct for both `kubectl` and `oc` (https://github.com/kubernetes-retired/external-storage/pull/969)
-- Point users to Helm and split up yamls (https://github.com/kubernetes-retired/external-storage/pull/995)
 - Use `kubernetes-sigs/sig-storage-lib-external-provisioner` instaed of `incubator/external-storage/lib` (https://github.com/kubernetes-retired/external-storage/pull/1026)
 - Fill in rbac.yaml with ServiceAccount manifest (https://github.com/kubernetes-retired/external-storage/pull/1060, https://github.com/kubernetes-retired/external-storage/pull/1179)
-- Fix some typos in README (https://github.com/kubernetes-retired/external-storage/pull/1054)
 - Make ARM deployment consistent with regular deployment (https://github.com/kubernetes-retired/external-storage/pull/1090)
 - Update Deployment apiVersion (from `extensions/v1beta1` to `apps/v1`) and added selector field (https://github.com/kubernetes-retired/external-storage/pull/1230/, https://github.com/kubernetes-retired/external-storage/pull/1231/, https://github.com/kubernetes-retired/external-storage/pull/1283/, https://github.com/kubernetes-retired/external-storage/pull/1294/)
 - Fix namespace in deployments (https://github.com/kubernetes-retired/external-storage/pull/1087, https://github.com/kubernetes-retired/external-storage/pull/1279)
@@ -15,7 +12,6 @@
 - Enable mountOptions from StorageClass to PersistentVolume (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/28)
 
 # v3.1.0
-- README Clarifications and minor formatting improvements (https://github.com/kubernetes-retired/external-storage/pull/938/)
 - Make leader-election configurable: default endpoints object namespace to controller's instead of kube-system (https://github.com/kubernetes-retired/external-storage/pull/957)
 
 # v3.0.1
@@ -37,7 +33,6 @@
 - Fix Makefile to build on OSX (https://github.com/kubernetes-retired/external-storage/pull/661)
 - Change the RBAC apiVersion from `rbac.authorization.k8s.io/v1alpha1` to `rbac.authorization.k8s.io/v1` (https://github.com/kubernetes-retired/external-storage/pull/656)
 - Add serviceAccount to deployment (https://github.com/kubernetes-retired/external-storage/pull/653)
-- README Improvements (https://github.com/kubernetes-retired/external-storage/pull/687)
 - Add namespace extended attributes to directory (https://github.com/kubernetes-retired/external-storage/pull/672)
 
 # v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v4.0.0
 - Remove redundant field in the rbac.yaml (https://github.com/kubernetes-retired/external-storage/pull/970)
-- Use `kubernetes-sigs/sig-storage-lib-external-provisioner` instaed of `incubator/external-storage/lib` (https://github.com/kubernetes-retired/external-storage/pull/1026)
+- Use `kubernetes-sigs/sig-storage-lib-external-provisioner` instead of `incubator/external-storage/lib` (https://github.com/kubernetes-retired/external-storage/pull/1026)
 - Fill in rbac.yaml with ServiceAccount manifest (https://github.com/kubernetes-retired/external-storage/pull/1060, https://github.com/kubernetes-retired/external-storage/pull/1179)
 - Make ARM deployment consistent with regular deployment (https://github.com/kubernetes-retired/external-storage/pull/1090)
 - Update Deployment apiVersion (from `extensions/v1beta1` to `apps/v1`) and added selector field (https://github.com/kubernetes-retired/external-storage/pull/1230/, https://github.com/kubernetes-retired/external-storage/pull/1231/, https://github.com/kubernetes-retired/external-storage/pull/1283/, https://github.com/kubernetes-retired/external-storage/pull/1294/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+# v4.0.0
+- Remove redundant field in the rbac.yaml (https://github.com/kubernetes-retired/external-storage/pull/970)
+- Fixing documentation to be correct for both `kubectl` and `oc` (https://github.com/kubernetes-retired/external-storage/pull/969)
+- Point nfs-client users to Helm and split up yamls (https://github.com/kubernetes-retired/external-storage/pull/995)
+- Use `kubernetes-sigs/sig-storage-lib-external-provisioner` instaed of `incubator/external-storage/lib` (https://github.com/kubernetes-retired/external-storage/pull/1026)
+- Fill in rbac.yaml with ServiceAccount manifest (https://github.com/kubernetes-retired/external-storage/pull/1060, https://github.com/kubernetes-retired/external-storage/pull/1179)
+- Fix some typos in README (https://github.com/kubernetes-retired/external-storage/pull/1054)
+- Make nfs-client ARM deployment consistent with regular deployment (https://github.com/kubernetes-retired/external-storage/pull/1090)
+- Update Deployment apiVersion (from `extensions/v1beta1` to `apps/v1`) and added selector field (https://github.com/kubernetes-retired/external-storage/pull/1230/, https://github.com/kubernetes-retired/external-storage/pull/1231/, https://github.com/kubernetes-retired/external-storage/pull/1283/, https://github.com/kubernetes-retired/external-storage/pull/1294/)
+- Fix namespace in deployments (https://github.com/kubernetes-retired/external-storage/pull/1087, https://github.com/kubernetes-retired/external-storage/pull/1279)
+
+# v3.1.0
+- README Clarifications and minor formatting improvements (https://github.com/kubernetes-retired/external-storage/pull/938/)
+- Make leader-election configurable: default endpoints object namespace to controller's instead of kube-system (https://github.com/kubernetes-retired/external-storage/pull/957)
+
+# v3.0.1
+- Fix archiveOnDelete parsing (https://github.com/kubernetes-retired/external-storage/pull/929)
+
+# v3.0.0
+- Adds archiveOnDelete parameter to provisioner (https://github.com/kubernetes-retired/external-storage/pull/905)
+- Change all clusterroles to have endpoints permissions and reduced events permissions, consolidate where possible (https://github.com/kubernetes-retired/external-storage/pull/892)
+
+# v2.1.2
+- Propagate StorageClass MountOptions to PVs (https://github.com/kubernetes-retired/external-storage/pull/835)
+- Skip deletion if the corresponding directory is not found (https://github.com/kubernetes-retired/external-storage/pull/859)
+
+# v2.1.1
+- Revert "Add namespace extended attributes to directory" (https://github.com/kubernetes-retired/external-storage/pull/816)
+
+# v2.1.0
+- Change the storage apiVersion from `storage.k8s.io/v1beta1` to `storage.k8s.io/v1` (https://github.com/kubernetes-retired/external-storage/pull/599)
+- Fix Makefile to build on OSX (https://github.com/kubernetes-retired/external-storage/pull/661)
+- Change the RBAC apiVersion from `rbac.authorization.k8s.io/v1alpha1` to `rbac.authorization.k8s.io/v1` (https://github.com/kubernetes-retired/external-storage/pull/656)
+- Add serviceAccount to deployment (https://github.com/kubernetes-retired/external-storage/pull/653)
+- README Improvements (https://github.com/kubernetes-retired/external-storage/pull/687)
+- Add namespace extended attributes to directory (https://github.com/kubernetes-retired/external-storage/pull/672)
+
 # v2.0.1
 - Add support for ARM (Raspberry PI). Image at `quay.io/external_storage/nfs-client-provisioner-arm`. (https://github.com/kubernetes-incubator/external-storage/pull/275)
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: nfs-subdir-external-provisioner
+              value: k8s-sigs.io/nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: <YOUR NFS SERVER HOSTNAME>
             - name: NFS_PATH
@@ -119,7 +119,7 @@ spec:
             path: /var/nfs
 ```
 
-You may also want to change the PROVISIONER_NAME above from `nfs-subdir-external-provisioner` to something more descriptive like `nfs-storage`, but if you do remember to also change the PROVISIONER_NAME in the storage class definition below.
+You may also want to change the PROVISIONER_NAME above from `k8s-sigs.io/nfs-subdir-external-provisioner` to something more descriptive like `nfs-storage`, but if you do remember to also change the PROVISIONER_NAME in the storage class definition below.
 
 To disable leader election, define an env variable named ENABLE_LEADER_ELECTION and set its value to false.
 
@@ -140,7 +140,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-nfs-storage
-provisioner: nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
+provisioner: k8s-sigs.io/nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   pathPattern: "${.PVC.namespace}/${.PVC.annotations.nfs.io/storage-path}" # waits for nfs.io/storage-path annotation, if not specified will accept as empty string.
   onDelete: delete

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: test-claim
-    annotations:
+  annotations:
     nfs.io/storage-path: "test-path" # not required, depending on whether this annotation was shown in the storage class description
 spec:
   storageClassName: managed-nfs-storage

--- a/deploy/class.yaml
+++ b/deploy/class.yaml
@@ -2,6 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-nfs-storage
-provisioner: nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
+provisioner: k8s-sigs.io/nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   archiveOnDelete: "false"

--- a/deploy/class.yaml
+++ b/deploy/class.yaml
@@ -2,6 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-nfs-storage
-provisioner: fuseim.pri/ifs # or choose another name, must match deployment's env PROVISIONER_NAME'
+provisioner: nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   archiveOnDelete: "false"

--- a/deploy/deployment-arm.yaml
+++ b/deploy/deployment-arm.yaml
@@ -27,7 +27,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: nfs-subdir-external-provisioner
+              value: k8s-sigs.io/nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/deployment-arm.yaml
+++ b/deploy/deployment-arm.yaml
@@ -27,7 +27,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: fuseim.pri/ifs
+              value: nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: nfs-subdir-external-provisioner
+              value: k8s-sigs.io/nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: fuseim.pri/ifs
+              value: nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/objects/class.yaml
+++ b/deploy/objects/class.yaml
@@ -2,6 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-nfs-storage
-provisioner: nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
+provisioner: k8s-sigs.io/nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   archiveOnDelete: "false"

--- a/deploy/objects/class.yaml
+++ b/deploy/objects/class.yaml
@@ -2,6 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-nfs-storage
-provisioner: fuseim.pri/ifs # or choose another name, must match deployment's env PROVISIONER_NAME'
+provisioner: nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   archiveOnDelete: "false"

--- a/deploy/objects/deployment-arm.yaml
+++ b/deploy/objects/deployment-arm.yaml
@@ -20,7 +20,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: fuseim.pri/ifs
+              value: nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/objects/deployment-arm.yaml
+++ b/deploy/objects/deployment-arm.yaml
@@ -20,7 +20,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: nfs-subdir-external-provisioner
+              value: k8s-sigs.io/nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/objects/deployment.yaml
+++ b/deploy/objects/deployment.yaml
@@ -20,7 +20,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: fuseim.pri/ifs
+              value: nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/objects/deployment.yaml
+++ b/deploy/objects/deployment.yaml
@@ -20,7 +20,7 @@ spec:
               mountPath: /persistentvolumes
           env:
             - name: PROVISIONER_NAME
-              value: nfs-subdir-external-provisioner
+              value: k8s-sigs.io/nfs-subdir-external-provisioner
             - name: NFS_SERVER
               value: 10.10.10.60
             - name: NFS_PATH

--- a/deploy/test-claim.yaml
+++ b/deploy/test-claim.yaml
@@ -2,8 +2,6 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: test-claim
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "managed-nfs-storage"
 spec:
   storageClassName: managed-nfs-storage
   accessModes:


### PR DESCRIPTION
### Update README
The examples still uses some old `volume.beta.kubernetes.io/storage-class` annotation which replaced by `storageClassName` and this strange `fuseim.pri/ifs` provisioner name.
Those both fixed by this PR.

### Updated CHANGELOG
The changelog is not updated since `v2.0.1` and if we soon want to release `v4.0.0` then we should fill the holes in the changelog.
In this PR I will fill the missing versions in the CHANGELOG by following the changes in `git log` in the deprecated repository between the version tags until it was deprecated. Then continue to do the same from this repository log until today.
