### PR TITLE
Change the helm chart kubeVersion semver to include pre-releases

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -4,7 +4,7 @@ description: nfs-subdir-external-provisioner is an automatic provisioner that us
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
 version: 3.0.0
-kubeVersion: ">=1.9.0 <1.20.0"
+kubeVersion: ">=1.9.0-0 <1.20.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
 keywords:


### PR DESCRIPTION
**What is this PR?**
The helm chart kubeVersion is set to `>=1.9.0 <1.20.0` which exclude pre-releases i.e `1.18.0-rc` and even `1.18.0-eks`.
This PR change the semver range to include such releases since they are supported.

this solution tested by using helm's chartutil `IsCompatibleRange` method.

ref: #38 