### PR TITLE
Configurable container registry server in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
-          registry: quay.io
+          registry: ${{ secrets.REGISTRY_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
       -

--- a/README.md
+++ b/README.md
@@ -200,5 +200,5 @@ The pipeline adds several labels:
 * `org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}`
 
 **Important:**
-* The pipeline performs the docker login command using `REGISTRY_USERNAME` and `REGISTRY_TOKEN` secrets, which have to be provided.
+* The pipeline performs the docker login command using `REGISTRY_SERVER`, `REGISTRY_USERNAME` and `REGISTRY_TOKEN` secrets, which have to be provided.
 * You also need to provide the `DOCKER_IMAGE` secret specifying your Docker image name, e.g., `quay.io/[username]/nfs-subdir-external-provisioner`.


### PR DESCRIPTION
**What is this PR?**

Breaking change to allow users to specify which container registry server to push multi-arch images. Terminology from [documentation](https://docs.docker.com/engine/reference/commandline/login/).