### PR TITLE
Add support for DaemonSets in Helm chart

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.0
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.2
+version: 4.0.3
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -54,7 +54,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `kind`                              | Kind of deployment (e.g. `Deployment` or `DaemonSet`)       | `Deployment`                                      |
 | `strategyType`                      | Specifies the strategy used to replace old Pods by new ones | `Recreate`                                        |
 | `image.repository`                  | Provisioner image                                           | `gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner` |
-| `image.tag`                         | Version of provisioner image                                | `v4.0.0`                                  |
+| `image.tag`                         | Version of provisioner image                                | `v4.0.0`                                          |
 | `image.pullPolicy`                  | Image pull policy                                           | `IfNotPresent`                                    |
 | `storageClass.name`                 | Name of the storageClass                                    | `nfs-client`                                      |
 | `storageClass.defaultClass`         | Set as the default StorageClass                             | `false`                                           |
@@ -65,7 +65,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `storageClass.accessModes`          | Set access mode for PV                                      | `ReadWriteOnce`                                   |
 | `leaderElection.enabled`            | Enables or disables leader election                         | `true`                                            |
 | `nfs.server`                        | Hostname of the NFS server (required)                       | null (ip or hostname)                             |
-| `nfs.path`                          | Basepath of the mount point to be used                      | `/nfs-storage`                                 |
+| `nfs.path`                          | Basepath of the mount point to be used                      | `/nfs-storage`                                    |
 | `nfs.mountOptions`                  | Mount options (e.g. 'nfsvers=3')                            | null                                              |
 | `resources`                         | Resources required (e.g. CPU, memory)                       | `{}`                                              |
 | `rbac.create`                       | Use Role-based Access Control                               | `true`                                            |

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -51,6 +51,7 @@ The following tables lists the configurable parameters of this chart and their d
 | Parameter                           | Description                                                 | Default                                           |
 | ----------------------------------- | ----------------------------------------------------------- | ------------------------------------------------- |
 | `replicaCount`                      | Number of provisioner instances to deployed                 | `1`                                               |
+| `kind`                              | Kind of deployment (e.g. `Deployment` or `DaemonSet`)       | `Deployment`                                      |
 | `strategyType`                      | Specifies the strategy used to replace old Pods by new ones | `Recreate`                                        |
 | `image.repository`                  | Provisioner image                                           | `gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner` |
 | `image.tag`                         | Version of provisioner image                                | `v4.0.0`                                  |

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.kind }}
 metadata:
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
   labels:
@@ -8,9 +8,11 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+{{- if eq .Values.kind "Deployment" }}
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: {{ .Values.strategyType }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "nfs-subdir-external-provisioner.name" . }}

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -1,3 +1,4 @@
+kind: Deployment
 replicaCount: 1
 strategyType: Recreate
 


### PR DESCRIPTION
Add support for `DaemonSets` in the helm chart to be able to support the provisioner on all nodes.