### PR TITLE
Add arm7 to multiarch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ all: build
 
 include release-tools/build.make
 
-BUILD_PLATFORMS=linux amd64; linux arm64 -arm64; linux ppc64le -ppc64le; linux s390x -s390x
+BUILD_PLATFORMS=linux amd64; linux arm -arm; linux arm64 -arm64; linux ppc64le -ppc64le; linux s390x -s390x


### PR DESCRIPTION
we are building arm64 but arm7 is 32bit and therefore another image is required.
it worth `v4.0.1` release imo

Fixes #57 