### PR TITLE
Setup chart linter as github action

### DIFF
--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -1,0 +1,18 @@
+name: Lint Helm Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (lint)
+        run: ct lint


### PR DESCRIPTION
As suggested by @james-d-elliott in https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/61#issuecomment-790292525 we can use `ct` which is the official tool for chart testing that contains linter that can prevent mistakes like we did by merging #56 without bumping the chart version.
the action will run on PR's and will fail if the chart changed but the version match the version in the origin master branch.