### PR TITLE
Fix the helm chart linter test failure

### DIFF
--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -15,4 +15,4 @@ jobs:
         uses: helm/chart-testing-action@v2.0.1
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --validate-maintainers=false

--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.0
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.3
+version: 4.0.4
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -37,7 +37,7 @@ storageClass:
 
   # Specifies a template for creating a directory path via PVC metadata's such as labels, annotations, name or namespace.
   # Ignored if value not set.
-  pathPattern: 
+  pathPattern:
 
   # Set access mode - ReadWriteOnce, ReadOnlyMany or ReadWriteMany
   accessModes: ReadWriteOnce


### PR DESCRIPTION
the chart linter is [failing](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/68/checks?check_run_id=2044525557) because our chart missing maintainers in the Chart.yaml and some trailing spaces.
this PR will disable this check. there are no official maintainers and the chart have enough links to the git repository if someone want to contact maintainers.