### PR TITLE
Helm chart labels and annotations and add missing image pull secrets in documentation

### DIFF
--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -15,4 +15,4 @@ jobs:
         uses: helm/chart-testing-action@v2.0.1
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --validate-maintainers=false

--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.0
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.3
+version: 4.0.5
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -48,31 +48,35 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of this chart and their default values.
 
-| Parameter                           | Description                                                 | Default                                           |
-| ----------------------------------- | ----------------------------------------------------------- | ------------------------------------------------- |
-| `replicaCount`                      | Number of provisioner instances to deployed                 | `1`                                               |
-| `strategyType`                      | Specifies the strategy used to replace old Pods by new ones | `Recreate`                                        |
+| Parameter                           | Description                                                 | Default                                                          |
+| ----------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| `replicaCount`                      | Number of provisioner instances to deployed                 | `1`                                                              |
+| `strategyType`                      | Specifies the strategy used to replace old Pods by new ones | `Recreate`                                                       |
 | `image.repository`                  | Provisioner image                                           | `gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner` |
-| `image.tag`                         | Version of provisioner image                                | `v4.0.0`                                  |
-| `image.pullPolicy`                  | Image pull policy                                           | `IfNotPresent`                                    |
-| `storageClass.name`                 | Name of the storageClass                                    | `nfs-client`                                      |
-| `storageClass.defaultClass`         | Set as the default StorageClass                             | `false`                                           |
-| `storageClass.allowVolumeExpansion` | Allow expanding the volume                                  | `true`                                            |
-| `storageClass.reclaimPolicy`        | Method used to reclaim an obsoleted volume                  | `Delete`                                          |
-| `storageClass.provisionerName`      | Name of the provisionerName                                 | null                                              |
-| `storageClass.archiveOnDelete`      | Archive pvc when deleting                                   | `true`                                            |
-| `storageClass.pathPattern`          | Specifies a template for the directory name                 | null                                              |
-| `storageClass.accessModes`          | Set access mode for PV                                      | `ReadWriteOnce`                                   |
-| `leaderElection.enabled`            | Enables or disables leader election                         | `true`                                            |
-| `nfs.server`                        | Hostname of the NFS server (required)                       | null (ip or hostname)                             |
-| `nfs.path`                          | Basepath of the mount point to be used                      | `/nfs-storage`                                 |
-| `nfs.mountOptions`                  | Mount options (e.g. 'nfsvers=3')                            | null                                              |
-| `resources`                         | Resources required (e.g. CPU, memory)                       | `{}`                                              |
-| `rbac.create`                       | Use Role-based Access Control                               | `true`                                            |
-| `podSecurityPolicy.enabled`         | Create & use Pod Security Policy resources                  | `false`                                           |
-| `priorityClassName`                 | Set pod priorityClassName                                   | null                                              |
-| `serviceAccount.create`             | Should we create a ServiceAccount                           | `true`                                            |
-| `serviceAccount.name`               | Name of the ServiceAccount to use                           | null                                              |
-| `nodeSelector`                      | Node labels for pod assignment                              | `{}`                                              |
-| `affinity`                          | Affinity settings                                           | `{}`                                              |
-| `tolerations`                       | List of node taints to tolerate                             | `[]`                                              |
+| `image.tag`                         | Version of provisioner image                                | `v4.0.0`                                                         |
+| `image.pullPolicy`                  | Image pull policy                                           | `IfNotPresent`                                                   |
+| `storageClass.name`                 | Name of the storageClass                                    | `nfs-client`                                                     |
+| `storageClass.defaultClass`         | Set as the default StorageClass                             | `false`                                                          |
+| `storageClass.allowVolumeExpansion` | Allow expanding the volume                                  | `true`                                                           |
+| `storageClass.reclaimPolicy`        | Method used to reclaim an obsoleted volume                  | `Delete`                                                         |
+| `storageClass.provisionerName`      | Name of the provisionerName                                 | null                                                             |
+| `storageClass.archiveOnDelete`      | Archive pvc when deleting                                   | `true`                                                           |
+| `storageClass.pathPattern`          | Specifies a template for the directory name                 | null                                                             |
+| `storageClass.accessModes`          | Set access mode for PV                                      | `ReadWriteOnce`                                                  |
+| `storageClass.annotations`          | Set additional annotations for the StorageClass             | `{}`                                                             |
+| `leaderElection.enabled`            | Enables or disables leader election                         | `true`                                                           |
+| `nfs.server`                        | Hostname of the NFS server (required)                       | null (ip or hostname)                                            |
+| `nfs.path`                          | Basepath of the mount point to be used                      | `/nfs-storage`                                                   |
+| `nfs.mountOptions`                  | Mount options (e.g. 'nfsvers=3')                            | null                                                             |
+| `resources`                         | Resources required (e.g. CPU, memory)                       | `{}`                                                             |
+| `rbac.create`                       | Use Role-based Access Control                               | `true`                                                           |
+| `podSecurityPolicy.enabled`         | Create & use Pod Security Policy resources                  | `false`                                                          |
+| `podAnnotations`                    | Additional annotations for the Pods                         | `{}`                                                             |
+| `priorityClassName`                 | Set pod priorityClassName                                   | null                                                             |
+| `serviceAccount.create`             | Should we create a ServiceAccount                           | `true`                                                           |
+| `serviceAccount.name`               | Name of the ServiceAccount to use                           | null                                                             |
+| `serviceAccount.annotations`        | Additional annotations for the ServiceAccount               | `{}`                                                             |
+| `nodeSelector`                      | Node labels for pod assignment                              | `{}`                                                             |
+| `affinity`                          | Affinity settings                                           | `{}`                                                             |
+| `tolerations`                       | List of node taints to tolerate                             | `[]`                                                             |
+| `labels`                            | Additional labels for any resource created                  | `{}`                                                             |

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `image.repository`                  | Provisioner image                                           | `gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner` |
 | `image.tag`                         | Version of provisioner image                                | `v4.0.0`                                                         |
 | `image.pullPolicy`                  | Image pull policy                                           | `IfNotPresent`                                                   |
+| `imagePullSecrets`                  | Image pull secrets                                          | `[]`                                                             |
 | `storageClass.name`                 | Name of the storageClass                                    | `nfs-client`                                                     |
 | `storageClass.defaultClass`         | Set as the default StorageClass                             | `false`                                                          |
 | `storageClass.allowVolumeExpansion` | Allow expanding the volume                                  | `true`                                                           |

--- a/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
+++ b/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
@@ -60,3 +60,22 @@ Return the appropriate apiVersion for podSecurityPolicy.
 {{- print "extensions/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nfs-subdir-external-provisioner.labels" -}}
+chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
+heritage: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nfs-subdir-external-provisioner.selectorLabels" -}}
+app: {{ template "nfs-subdir-external-provisioner.name" . }}
+release: {{ .Release.Name }}
+{{- end }}

--- a/charts/nfs-subdir-external-provisioner/templates/clusterrole.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/clusterrole.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}-runner
 rules:
   - apiGroups: [""]

--- a/charts/nfs-subdir-external-provisioner/templates/clusterrolebinding.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/clusterrolebinding.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: run-{{ template "nfs-subdir-external-provisioner.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -3,27 +3,25 @@ kind: Deployment
 metadata:
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: {{ .Values.strategyType }}
   selector:
     matchLabels:
-      app: {{ template "nfs-subdir-external-provisioner.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "nfs-subdir-external-provisioner.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and (.Values.tolerations) (semverCompare "<1.6-0" .Capabilities.KubeVersion.GitVersion) }}
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
       {{- end }}
       labels:
-        app: {{ template "nfs-subdir-external-provisioner.name" . }}
-        release: {{ .Release.Name }}
+        {{- include "nfs-subdir-external-provisioner.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
       {{- if .Values.nodeSelector }}
@@ -37,9 +35,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
-      {{- if .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
       {{- end }}
       labels:
-        {{- include "nfs-subdir-external-provisioner.labels" . | nindent 8 }}
+        {{- include "nfs-subdir-external-provisioner.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
       {{- if .Values.nodeSelector }}

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolume
 metadata:
   name: pv-{{ template "nfs-subdir-external-provisioner.fullname" . }}
   labels: 
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
     nfs-subdir-external-provisioner: {{ template "nfs-subdir-external-provisioner.fullname" . }}
 spec:
   capacity:

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvc-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  labels:
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.storageClass.accessModes }}

--- a/charts/nfs-subdir-external-provisioner/templates/podsecuritypolicy.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/podsecuritypolicy.yaml
@@ -4,10 +4,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/charts/nfs-subdir-external-provisioner/templates/role.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/role.yaml
@@ -3,10 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
 rules:
   - apiGroups: [""]

--- a/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
@@ -3,9 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
 {{- end -}}

--- a/charts/nfs-subdir-external-provisioner/templates/storageclass.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/storageclass.yaml
@@ -5,13 +5,13 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: {{ .Values.storageClass.name }}
-{{- if .Values.storageClass.defaultClass }}
   annotations:
+  {{- if .Values.storageClass.defaultClass }}
     storageclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
   {{- with .Values.storageClass.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
 provisioner: {{ template "nfs-subdir-external-provisioner.provisionerName" . }}
 allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}

--- a/charts/nfs-subdir-external-provisioner/templates/storageclass.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/storageclass.yaml
@@ -3,14 +3,14 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   labels:
-    app: {{ template "nfs-subdir-external-provisioner.name" . }}
-    chart: {{ template "nfs-subdir-external-provisioner.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: {{ .Values.storageClass.name }}
 {{- if .Values.storageClass.defaultClass }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+  {{- with .Values.storageClass.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 provisioner: {{ template "nfs-subdir-external-provisioner.provisionerName" . }}
 allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -5,6 +5,7 @@ image:
   repository: gcr.io/k8s-staging-sig-storage/nfs-subdir-external-provisioner
   tag: v4.0.0
   pullPolicy: IfNotPresent
+imagePullSecrets: []
 
 nfs:
   server:
@@ -37,10 +38,13 @@ storageClass:
 
   # Specifies a template for creating a directory path via PVC metadata's such as labels, annotations, name or namespace.
   # Ignored if value not set.
-  pathPattern: 
+  pathPattern:
 
   # Set access mode - ReadWriteOnce, ReadOnlyMany or ReadWriteMany
   accessModes: ReadWriteOnce
+
+  # Storage class annotations
+  annotations: {}
 
 leaderElection:
   # When set to false leader election will be disabled
@@ -56,12 +60,18 @@ rbac:
 podSecurityPolicy:
   enabled: false
 
+# Deployment pod annotations
+podAnnotations: {}
+
 ## Set pod priorityClassName
 # priorityClassName: ""
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+
+  # Annotations to add to the service account
+  annotations: {}
 
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
@@ -80,3 +90,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Additional labels for any resource created
+labels: {}


### PR DESCRIPTION
Fixes #63 

Adds the ability to add custom labels to created resources 
also adds the ability to add annotations to: storage class, pod and service account.
also, there was a missing documentation of image pull secrets that was exists but missing from values.yaml and readme.

the default labels should have been from `app.kubernetes.io/` namespace and not just `name` or `release` by the best practices but it may breaks compatibility to someone and anyway `matchLabels` (selectorLabels) are immutable once created so i gave up on that.
the changes tested and are the it is upgrade-able and backward compatible.