### PR TITLE
prevent mounting of root directory

### DIFF
--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -104,8 +104,10 @@ func (p *nfsProvisioner) Provision(ctx context.Context, options controller.Provi
 	pathPattern, exists := options.StorageClass.Parameters["pathPattern"]
 	if exists {
 		customPath := metadata.stringParser(pathPattern)
-		path = filepath.Join(p.path, customPath)
-		fullPath = filepath.Join(mountPath, customPath)
+		if customPath != "" {
+			path = filepath.Join(p.path, customPath)
+			fullPath = filepath.Join(mountPath, customPath)
+		}
 	}
 
 	glog.V(4).Infof("creating path %s", fullPath)


### PR DESCRIPTION
If storageClass enable pathPattern like:

`pathPattern: "${.PVC.annotations.nfs.io/storage-path}"`

but pvc without annotation would make empty `customPath` and create a pv with nfs root path.