### PR TITLE
Use podLabels with user defined labels in deployment pod template

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.10
+version: 4.0.11
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
+++ b/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
@@ -74,6 +74,16 @@ heritage: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Pod template labels
+*/}}
+{{- define "nfs-subdir-external-provisioner.podLabels" -}}
+{{ include "nfs-subdir-external-provisioner.selectorLabels" . }}
+{{- with .Values.labels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "nfs-subdir-external-provisioner.selectorLabels" -}}

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
       {{- end }}
       labels:
-        {{- include "nfs-subdir-external-provisioner.selectorLabels" . | nindent 8 }}
+        {{- include "nfs-subdir-external-provisioner.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
       {{- if .Values.nodeSelector }}


### PR DESCRIPTION
PR #72 adds the ability to specify labels for all objects created but it does not allow to control the deployment's pods labels which is sometimes important.
we [can't](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/72#discussion_r594247776) just use `nfs-subdir-external-provisioner.labels` because it contains version information and will force redeployment every chart upgrade. instead, we will use `nfs-subdir-external-provisioner.podLabels` which consist of `nfs-subdir-external-provisioner.selectorLabels` and user defined labels.

Fixes #63
/cc @mkilchhofer
/cc @kmova 
/assign @kmova 