### PR TITLE
Update sed command for OpenShift in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ On OpenShift the service account used to bind volumes does not have the necessar
 ```sh
 # Set the subject of the RBAC objects to the current namespace where the provisioner is being deployed
 $ NAMESPACE=`oc project -q`
-$ sed -i'' "s/namespace:.*/namespace: $NAMESPACE/g" ./deploy/rbac.yaml
+$ sed -i'' "s/namespace:.*/namespace: $NAMESPACE/g" ./deploy/rbac.yaml ./deploy/deployment.yaml
 $ oc create -f deploy/rbac.yaml
 $ oc adm policy add-scc-to-user hostmount-anyuid system:serviceaccount:$NAMESPACE:nfs-client-provisioner
 ```


### PR DESCRIPTION
In the set up authorization section of the README replace namespace in `./deploy/deployment.yaml` as well for OpenShift deployments since it is set to the default namespace