### PR TITLE
helm chart: allow persistentVolumeClaim in psp or pod never launches

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.12
+version: 4.0.13
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/templates/podsecuritypolicy.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/podsecuritypolicy.yaml
@@ -13,6 +13,7 @@ spec:
   volumes:
     - 'secret'
     - 'nfs'
+    - 'persistentVolumeClaim'
   hostNetwork: false
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
Simple fix, but if you have podsecuritypolicy in your cluster, this chart doesn't work without this change.