### PR TITLE
test: update image used by test-pod

### DIFF
--- a/deploy/test-pod.yaml
+++ b/deploy/test-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-pod
-    image: gcr.io/google_containers/busybox:1.24
+    image: busybox:stable
     command:
       - "/bin/sh"
     args:


### PR DESCRIPTION
Changing the images used in the test-pod to a more recent tag that also has multi-arch builds.

Previously on an arm processor the test-pod would show Failed with not much hints as to why.

Closes #131 