### PR TITLE
Separate reclaimPolicies for auto-generated StorageClass and main NFS PV

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.13
+version: 4.0.14
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -71,6 +71,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `nfs.path`                          | Basepath of the mount point to be used                                                                | `/nfs-storage`                                           |
 | `nfs.mountOptions`                  | Mount options (e.g. 'nfsvers=3')                                                                      | null                                                     |
 | `nfs.volumeName`                    | Volume name used inside the pods                                                                      | `nfs-subdir-external-provisioner-root`                   |
+| `nfs.reclaimPolicy`                 | Reclaim policy for the main nfs volume used for subdir provisioning                                   | `Retain`                                                 |
 | `resources`                         | Resources required (e.g. CPU, memory)                                                                 | `{}`                                                     |
 | `rbac.create`                       | Use Role-based Access Control                                                                         | `true`                                                   |
 | `podSecurityPolicy.enabled`         | Create & use Pod Security Policy resources                                                            | `false`                                                  |

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
@@ -12,7 +12,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - {{ .Values.storageClass.accessModes }}
-  persistentVolumeReclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+  persistentVolumeReclaimPolicy: {{ .Values.nfs.reclaimPolicy }}
   storageClassName: ""
   {{- if .Values.nfs.mountOptions }}
   mountOptions:

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -12,7 +12,8 @@ nfs:
   path: /nfs-storage
   mountOptions:
   volumeName: nfs-subdir-external-provisioner-root
-  reclaimPolicy: Retain # Reclaim policy for the main nfs volume
+  # Reclaim policy for the main nfs volume
+  reclaimPolicy: Retain
 
 # For creating the StorageClass automatically:
 storageClass:

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -12,6 +12,7 @@ nfs:
   path: /nfs-storage
   mountOptions:
   volumeName: nfs-subdir-external-provisioner-root
+  reclaimPolicy: Delete # Reclaim policy for the main nfs volume
 
 # For creating the StorageClass automatically:
 storageClass:

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -12,7 +12,7 @@ nfs:
   path: /nfs-storage
   mountOptions:
   volumeName: nfs-subdir-external-provisioner-root
-  reclaimPolicy: Delete # Reclaim policy for the main nfs volume
+  reclaimPolicy: Retain # Reclaim policy for the main nfs volume
 
 # For creating the StorageClass automatically:
 storageClass:


### PR DESCRIPTION
This Pull request adds a new value in values.yaml, `nfs.reclaimPolicy` that defines the reclaimPolicy for the main NFS persistentVolume.

Currently the reclaimPolicy is set to the same value as the one for the autogenerated StorageClass, but that is not what is wanted/needed in some use cases. See https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/issues/128 for a further description of when we want these reclaimPolicies to differ.

Fixes: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/issues/128