### PR TITLE
Allow subfolders with onDelete option

### DIFF
--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -141,6 +141,7 @@ func (p *nfsProvisioner) Provision(ctx context.Context, options controller.Provi
 
 func (p *nfsProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {
 	path := volume.Spec.PersistentVolumeSource.NFS.Path
+	basePath := filepath.Base(path)
 	oldPath := strings.Replace(path, p.path, mountPath, 1)
 
 	if _, err := os.Stat(oldPath); os.IsNotExist(err) {

--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -141,8 +141,7 @@ func (p *nfsProvisioner) Provision(ctx context.Context, options controller.Provi
 
 func (p *nfsProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {
 	path := volume.Spec.PersistentVolumeSource.NFS.Path
-	basePath := strings.Replace(path, p.path, mountPath, 1)
-	oldPath := filepath.Join(mountPath, basePath)
+	oldPath := strings.Replace(path, p.path, mountPath, 1)
 
 	if _, err := os.Stat(oldPath); os.IsNotExist(err) {
 		glog.Warningf("path %s does not exist, deletion skipped", oldPath)

--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -141,7 +141,7 @@ func (p *nfsProvisioner) Provision(ctx context.Context, options controller.Provi
 
 func (p *nfsProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {
 	path := volume.Spec.PersistentVolumeSource.NFS.Path
-	basePath := filepath.Base(path)
+	basePath := strings.Replace(path, p.path, mountpath, 1)
 	oldPath := filepath.Join(mountPath, basePath)
 
 	if _, err := os.Stat(oldPath); os.IsNotExist(err) {

--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -141,7 +141,7 @@ func (p *nfsProvisioner) Provision(ctx context.Context, options controller.Provi
 
 func (p *nfsProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {
 	path := volume.Spec.PersistentVolumeSource.NFS.Path
-	basePath := strings.Replace(path, p.path, mountpath, 1)
+	basePath := strings.Replace(path, p.path, mountPath, 1)
 	oldPath := filepath.Join(mountPath, basePath)
 
 	if _, err := os.Stat(oldPath); os.IsNotExist(err) {


### PR DESCRIPTION
Fixes issue #127 by replacing the NFS server path from PV in provisioners Delete method with the mountPath instead of using the paths.Base() method