### PR TITLE
docs: consistent StorageClass names, multiple provisioners installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This is `deploy/class.yaml` which defines the NFS subdir external provisioner's 
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: managed-nfs-storage
+  name: nfs-client
 provisioner: k8s-sigs.io/nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   pathPattern: "${.PVC.namespace}/${.PVC.annotations.nfs.io/storage-path}" # waits for nfs.io/storage-path annotation, if not specified will accept as empty string.
@@ -166,7 +166,7 @@ metadata:
   annotations:
     nfs.io/storage-path: "test-path" # not required, depending on whether this annotation was shown in the storage class description
 spec:
-  storageClassName: managed-nfs-storage
+  storageClassName: nfs-client
   accessModes:
     - ReadWriteMany
   resources:

--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.14
+version: 4.0.16
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -30,7 +30,7 @@ $ helm install my-release nfs-subdir-external-provisioner/nfs-subdir-external-pr
     --set nfs.path=/exported/path
 ```
 
-The command deploys the given storage class in the default configuration. It can be used afterswards to provision persistent volumes. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys the given storage class in the default configuration. It can be used afterwards to provision persistent volumes. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -84,3 +84,15 @@ The following tables lists the configurable parameters of this chart and their d
 | `affinity`                          | Affinity settings                                                                                     | `{}`                                                     |
 | `tolerations`                       | List of node taints to tolerate                                                                       | `[]`                                                     |
 | `labels`                            | Additional labels for any resource created                                                            | `{}`                                                     |
+
+## Install Multiple Provisioners
+
+It is possible to install more than one provisioner in your cluster to have access to multiple nfs servers and/or multiple exports from a single nfs server. Each provisioner must have a different `storageClass.provisionerName` and therefore a different `storageClass.name`. For example:
+
+```console
+helm install second-nfs-subdir-external-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+    --set nfs.server=y.y.y.y \
+    --set nfs.path=/other/exported/path \
+    --set storageClass.name=second-nfs-client \
+    --set storageClass.provisionerName=k8s-sigs.io/second-nfs-subdir-external-provisioner
+```

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -87,7 +87,7 @@ The following tables lists the configurable parameters of this chart and their d
 
 ## Install Multiple Provisioners
 
-It is possible to install more than one provisioner in your cluster to have access to multiple nfs servers and/or multiple exports from a single nfs server. Each provisioner must have a different `storageClass.provisionerName` and therefore a different `storageClass.name`. For example:
+It is possible to install more than one provisioner in your cluster to have access to multiple nfs servers and/or multiple exports from a single nfs server. Each provisioner must have a different `storageClass.provisionerName` and a different `storageClass.name`. For example:
 
 ```console
 helm install second-nfs-subdir-external-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \

--- a/deploy/class.yaml
+++ b/deploy/class.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: managed-nfs-storage
+  name: nfs-client
 provisioner: k8s-sigs.io/nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   archiveOnDelete: "false"

--- a/deploy/objects/class.yaml
+++ b/deploy/objects/class.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: managed-nfs-storage
+  name: nfs-client
 provisioner: k8s-sigs.io/nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
 parameters:
   archiveOnDelete: "false"

--- a/deploy/test-claim.yaml
+++ b/deploy/test-claim.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: test-claim
 spec:
-  storageClassName: managed-nfs-storage
+  storageClassName: nfs-client
   accessModes:
     - ReadWriteMany
   resources:


### PR DESCRIPTION
This PR solves the inconsistency in StorageClass names in the `deploy/` directory and the helm chart, which makes it hard for new users to test their helm installation with `deploy/test-claim.yaml`.
I also added documentation about how to install multiple provisioners on a single cluster because I remember people had troubles with that in the past. 
(and a small typo...)

Related to: #118, #95, #78
Closes #164 
CC @kmova 