### PR TITLE
Match deploy/*.yaml and deploy/objects/*.yaml

### DIFF
--- a/deploy/objects/clusterrolebinding.yaml
+++ b/deploy/objects/clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: nfs-client-provisioner
+    # replace with namespace where provisioner is deployed
     namespace: default
 roleRef:
   kind: ClusterRole

--- a/deploy/objects/deployment.yaml
+++ b/deploy/objects/deployment.yaml
@@ -1,11 +1,18 @@
+apiVersion: apps/v1
 kind: Deployment
-apiVersion: extensions/v1beta1
 metadata:
   name: nfs-client-provisioner
+  labels:
+    app: nfs-client-provisioner
+  # replace with namespace where provisioner is deployed
+  namespace: default
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: nfs-client-provisioner
   template:
     metadata:
       labels:
@@ -22,11 +29,11 @@ spec:
             - name: PROVISIONER_NAME
               value: k8s-sigs.io/nfs-subdir-external-provisioner
             - name: NFS_SERVER
-              value: 10.10.10.60
+              value: 10.3.243.101
             - name: NFS_PATH
               value: /ifs/kubernetes
       volumes:
         - name: nfs-client-root
           nfs:
-            server: 10.10.10.60
+            server: 10.3.243.101
             path: /ifs/kubernetes

--- a/deploy/objects/role.yaml
+++ b/deploy/objects/role.yaml
@@ -2,6 +2,8 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: leader-locking-nfs-client-provisioner
+  # replace with namespace where provisioner is deployed
+  namespace: default
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/deploy/objects/rolebinding.yaml
+++ b/deploy/objects/rolebinding.yaml
@@ -2,6 +2,8 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: leader-locking-nfs-client-provisioner
+  # replace with namespace where provisioner is deployed
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: nfs-client-provisioner

--- a/deploy/objects/serviceaccount.yaml
+++ b/deploy/objects/serviceaccount.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nfs-client-provisioner
+  # replace with namespace where provisioner is deployed
+  namespace: default


### PR DESCRIPTION
`deploy/*.yaml` and `deploy/objects/*.yaml` are not matched.
`deploy/objects/*.yaml` uses `extensions/v1beta1 Deployment` and looks old, so it has updated.