### PR TITLE
Add securityContext options to Helm Chart, bump chart version - Related to Issue #97

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.14
+version: 4.0.15
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
         {{- include "nfs-subdir-external-provisioner.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
+      securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -43,6 +45,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
             - name: {{ .Values.nfs.volumeName }}
               mountPath: /persistentvolumes

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       serviceAccountName: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
       securityContext:
-      {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -74,6 +74,10 @@ podAnnotations: {}
 ## Set pod priorityClassName
 # priorityClassName: ""
 
+podSecurityContext: {}
+
+securityContext: {}
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
Continuing https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/105, as it appears to be abandoned. I have bumped the chart version as requested in the previous MR.

This MR adds `securityContext` and `podSecurityContext` templates to the helm chart.

(new MR to fix authorship hopefully!)