### PR TITLE
Fix Go version verification.

### DIFF
--- a/release-tools/verify-go-version.sh
+++ b/release-tools/verify-go-version.sh
@@ -31,7 +31,7 @@ version=$("$GO" version) || die "determining version of $GO failed"
 majorminor=$(echo "$version" | sed -e 's/.*go\([0-9]*\)\.\([0-9]*\).*/\1.\2/')
 # SC1091: Not following: release-tools/prow.sh was not specified as input (see shellcheck -x).
 # shellcheck disable=SC1091
-expected=$(. release-tools/prow.sh >/dev/null && echo "$CSI_PROW_GO_VERSION_BUILD")
+expected=$(. release-tools/prow.sh >/dev/null && echo "${CSI_PROW_GO_VERSION_BUILD%.*}")
 
 if [ "$majorminor" != "$expected" ]; then
     cat >&2 <<EOF


### PR DESCRIPTION
### Description

When running the script, it only looks for major and minor versions and ignores the bug fixes. However, the script compares the full _expected_ version and is thus always different.

### Context

I was going to contribute to the issue https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/issues/167 when I noticed it was a duplicate of https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/issues/127. During the setup, after upgrading my go version, I still got the following message:

```
======================================================
                  WARNING

  This projects is tested with Go v1.17.3.
  Your current Go version is v1.17.
  This may or may not be close enough.

  In particular test-gofmt and test-vendor
  are known to be sensitive to the version of
  Go.
======================================================
```

With the modification, it removes whatever comes after the last _dot_ with bash variable expansion and only major and minor versions are compared.