### PR TITLE
Fix onDelete option for subdirectories

### DIFF
--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -146,7 +146,7 @@ func (p *nfsProvisioner) Provision(ctx context.Context, options controller.Provi
 func (p *nfsProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {
 	path := volume.Spec.PersistentVolumeSource.NFS.Path
 	basePath := filepath.Base(path)
-	oldPath := filepath.Join(mountPath, basePath)
+	oldPath := strings.Replace(path, p.path, mountPath, 1)
 
 	if _, err := os.Stat(oldPath); os.IsNotExist(err) {
 		glog.Warningf("path %s does not exist, deletion skipped", oldPath)


### PR DESCRIPTION
fixes issue #127 by using the full nfs path set in p.path and replacing the host path of the nfs server with the mount path using strings.Replace instead of just joining the basePath