### PR TITLE
remove BUILD_PLATFORM variable setting from the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,3 @@ all: build
 
 include release-tools/build.make
 
-BUILD_PLATFORMS=linux amd64; linux arm -arm; linux arm64 -arm64; linux ppc64le -ppc64le; linux s390x -s390x


### PR DESCRIPTION
as the tuple of BUILD_PLATFORM changed for csi-release-tools for
multi-arch builds, we need to   either correct the variable
in the repo or delegate that setting to csi-release-tool setting.

Ref # https://github.com/kubernetes-csi/csi-release-tools/pull/181

This is causing the test to fail as seen here:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/canary-nfs-subdir-external-provisioner-push-images/1521591446950383616

Fix # https://github.com/kubernetes/kubernetes/issues/109910
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>