### PR TITLE
better example for helm mountOptions

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.16
+version: 4.0.17
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -69,7 +69,7 @@ The following tables lists the configurable parameters of this chart and their d
 | `leaderElection.enabled`            | Enables or disables leader election                                                                   | `true`                                                   |
 | `nfs.server`                        | Hostname of the NFS server (required)                                                                 | null (ip or hostname)                                    |
 | `nfs.path`                          | Basepath of the mount point to be used                                                                | `/nfs-storage`                                           |
-| `nfs.mountOptions`                  | Mount options (e.g. 'nfsvers=3')                                                                      | null                                                     |
+| `nfs.mountOptions`                  | Mount options (e.g. {"nolock"\\,"nfsvers=3"})                                                         | null                                                     |
 | `nfs.volumeName`                    | Volume name used inside the pods                                                                      | `nfs-subdir-external-provisioner-root`                   |
 | `nfs.reclaimPolicy`                 | Reclaim policy for the main nfs volume used for subdir provisioning                                   | `Retain`                                                 |
 | `resources`                         | Resources required (e.g. CPU, memory)                                                                 | `{}`                                                     |


### PR DESCRIPTION
with current example  `--set nfs.mountOptions='nfsvers=3'` I got error in helm: 

```console
Error: INSTALLATION FAILED: template: nfs-subdir-external-provisioner/templates/storageclass.yaml:28:19: executing "nfs-subdir-external-provisioner/templates/storageclass.yaml" at <.Values.nfs.mountOptions>: range can't iterate over nfsvers=3
helm.go:84: [debug] template: nfs-subdir-external-provisioner/templates/storageclass.yaml:28:19: executing "nfs-subdir-external-provisioner/templates/storageclass.yaml" at <.Values.nfs.mountOptions>: range can't iterate over nfsvers=3
INSTALLATION FAILED
```

this works better for me: 
`	--set nfs.mountOptions={"nfsvers=3"}`
or with other 
`--set nfs.mountOptions={"nolock\,nfsvers=3"}`
