### PR TITLE
build: build multiarch image with golang 1.18

### DIFF
--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.14 as build-env
+FROM --platform=$BUILDPLATFORM golang:1.18 as build-env
 
 # xx wraps go to automatically configure $GOOS, $GOARCH, and $GOARM
 # based on TARGETPLATFORM provided by Docker.


### PR DESCRIPTION
since commit 656623a00ff44aeb4c9d506c0fe63e1194345306 (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/175)  the multiarch docker image cannot be built with golang 1.14 anymore.
at least 1.17 is required, but prow.sh validates golang 1.18 ([prow.sh#L89](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/release-tools/prow.sh#L89)) so we will use 1.18 from now.

i am wondering, does that mean that we need to bump go.mod version as well ([go.mod#L3](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/go.mod#L3))?