### PR TITLE
build: fix build platforms to new scheme

### DIFF
--- a/.cloudbuild.sh
+++ b/.cloudbuild.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64; linux arm -arm; linux arm64 -arm64; linux ppc64le -ppc64le; linux s390x -s390x"}
+: ${CSI_PROW_BUILD_PLATFORMS:="linux amd64 amd64; linux arm arm -arm; linux arm64 arm64 -arm64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x"}
 
 # shellcheck disable=SC1091
 . release-tools/cloudbuild.sh

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,4 @@ all: build
 
 include release-tools/build.make
 
+ BUILD_PLATFORMS=linux amd64 amd64; linux arm arm -arm; linux arm64 arm64 -arm64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x


### PR DESCRIPTION
Since https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/179 merged, the build platforms scheme changed (https://github.com/kubernetes-csi/csi-release-tools/commit/05c1801), and since then our build failed every time because the arguments aren't parsed correctly and causing the build to [fail](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-nfs-subdir-external-provisioner-push-images/1529885937834659840#1:build-log.txt%3A332).
now it's should be ok. 

Related to https://github.com/kubernetes/kubernetes/issues/109910
Related to https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/199