### PR TITLE
test: add tirvy vulnerability scanner github action

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,34 @@
+name: Vulnerability Scanner
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
+      - name: Build images from Dockerfile
+        run: |
+          make BUILD_PLATFORMS="linux amd64 amd64" container
+
+      - name: Run Trivy vulnerability scanner on nfs-subdir-external-provisioner image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'nfs-subdir-external-provisioner:latest'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'


### PR DESCRIPTION
in addition the fixes already done to solve vulnerabilities in the repository, this new github action will allow us to make sure we will keep it that way in the future by running trivy scan on any pull request (and every push to master) and fail if any vulnerability found (and can be fixed).



projects that done it already (that I can find):
1. https://github.com/kubernetes-csi/external-snapshotter/pull/708
2. https://github.com/kubernetes-csi/livenessprobe/pull/149


related to: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/issues/205

/cc @kmova
/cc @msau42
/cc @xing-yang