### PR TITLE
Added reference to namespaces in templates

### DIFF
--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvc-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:

--- a/charts/nfs-subdir-external-provisioner/templates/role.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/role.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}

--- a/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
In this way it is possible to generate YAMLs with the correct namespace also using the `helm template`  command.