### PR TITLE
Improvements to allow more advanced deployments such as Kerberized NFS support

### DIFF
--- a/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
+++ b/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
@@ -90,3 +90,16 @@ Selector labels
 app: {{ template "nfs-subdir-external-provisioner.name" . }}
 release: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
           volumeMounts:
             - name: {{ .Values.nfs.volumeName }}
               mountPath: /persistentvolumes
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
           env:
             - name: PROVISIONER_NAME
               value: {{ template "nfs-subdir-external-provisioner.provisionerName" . }}
@@ -61,10 +64,16 @@ spec:
             - name: ENABLE_LEADER_ELECTION
               value: "false"
             {{- end }}
+          {{- if .Values.extraEnvVars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
 {{ toYaml . | indent 12 }}
           {{- end }}
+      {{- if .Values.extraContainers }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
+      {{- end }}
       volumes:
         - name: {{ .Values.nfs.volumeName }}
 {{- if .Values.buildMode }}
@@ -77,6 +86,9 @@ spec:
             server: {{ .Values.nfs.server }}
             path: {{ .Values.nfs.path }}
 {{- end }}
+      {{- if .Values.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
       {{- if and (.Values.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -66,6 +66,18 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
 
+# Additional sidecars
+extraContainers: {}
+
+# Additional env vars
+extraEnvVars: {}
+
+# Additional volumes
+extraVolumes: {}
+
+# Additional volume mounts
+extraVolumeMounts: {}
+
 # If true, create & use Pod Security Policy resources
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 podSecurityPolicy:


### PR DESCRIPTION
Support Kerberized NFS (`krb5p`) adding `extraContainers`, `extraEnvVars`, `extraVolumes` & `extraVolumeMounts` to allow more advanced deployments. 

To support Kerberized NFS `values.yaml` may contain:
```
extraVolumes:
  - name: krb5-config
    configMap:
      name: kerberos-config
  - name: kcmsocket
    hostPath:
      path: /var/run/.heim_org.h5l.kcm-socket
      type: Socket
  - name: keytab
    secret:
      secretName: nfs-krb5-principal
      optional: false
      items:
      - key: nfs
        path: keytab
extraVolumeMounts:
  - name: kcmsocket
    mountPath: /var/run/.heim_org.h5l.kcm-socket
extraEnvVars:
  - name: KRB5CCNAME
    value: "KCM:"
extraContainers:
  - name: kinit
    image: kerberos:0.10.0
    env:
      - name: KRB5CCNAME
        value: "KCM:"
      - name: KERBEROS_RENEWAL_TIME
        value: "86400"
    command:
      - bash
      - -ec
      - |
        kinit -kt /secrets/keytab nfs-principal
        while true; do
          kinit -R
          sleep ${KERBEROS_RENEWAL_TIME}
        done
    volumeMounts:
      - name: krb5-config
        mountPath: /etc/krb5.conf
        subPath: krb5.conf
      - name: kcmsocket
        mountPath: /var/run/.heim_org.h5l.kcm-socket
      - name: keytab
        mountPath: /secrets
    lifecycle:
      preStop:
       exec:
         command: ["/usr/bin/kdestroy"]
```
This will allow to deploy a sidecar that manages the Kerberos ticket throughout NFS external subdir provisioner lifecycle.