### PR TITLE
Update refs from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **NFS subdir external provisioner** is an automatic provisioner that use your _existing and already configured_ NFS server to support dynamic provisioning of Kubernetes Persistent Volumes via Persistent Volume Claims. Persistent volumes are provisioned as `${namespace}-${pvcName}-${pvName}`.
 
 Note: This repository is migrated from https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client. As part of the migration:
-- The container image name and repository has changed to `k8s.gcr.io/sig-storage` and `nfs-subdir-external-provisioner` respectively.
+- The container image name and repository has changed to `registry.k8s.io/sig-storage` and `nfs-subdir-external-provisioner` respectively.
 - To maintain backward compatibility with earlier deployment files, the naming of NFS Client Provisioner is retained as `nfs-client-provisioner` in the deployment YAMLs.
 - One of the pending areas for development on this repository is to add automated e2e tests. If you would like to contribute, please raise an issue or reach us on the Kubernetes slack #sig-storage channel.
 
@@ -208,7 +208,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
+          image: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -52,7 +52,7 @@ The following tables lists the configurable parameters of this chart and their d
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | `replicaCount`                      | Number of provisioner instances to deployed                                                           | `1`                                                      |
 | `strategyType`                      | Specifies the strategy used to replace old Pods by new ones                                           | `Recreate`                                               |
-| `image.repository`                  | Provisioner image                                                                                     | `k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner` |
+| `image.repository`                  | Provisioner image                                                                                     | `registry.k8s.io/sig-storage/nfs-subdir-external-provisioner` |
 | `image.tag`                         | Version of provisioner image                                                                          | `v4.0.2`                                                 |
 | `image.pullPolicy`                  | Image pull policy                                                                                     | `IfNotPresent`                                           |
 | `imagePullSecrets`                  | Image pull secrets                                                                                    | `[]`                                                     |

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 strategyType: Recreate
 
 image:
-  repository: k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner
+  repository: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner
   tag: v4.0.2
   pullPolicy: IfNotPresent
 imagePullSecrets: []

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
+          image: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes

--- a/deploy/objects/deployment.yaml
+++ b/deploy/objects/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
+          image: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -100,7 +100,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. If release was a new major/minor version, create a new `release-<minor>`
    branch at that commit.
 1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
-1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
+1. Promote images from k8s-staging-sig-storage to registry.k8s.io/sig-storage. From
    the [k8s image
    repo](https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage),
    run `./generate.sh > images.yaml`, and send a PR with the updated images.


### PR DESCRIPTION
With the [change to defaulting](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) to registry.k8s.io as our image registry and the [planned freeze in April](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), projects within the Kubernetes orgs need to update their image references to point to the new address.

ref: https://github.com/kubernetes/k8s.io/issues/4738