### PR TITLE
Small typo fix in values.yaml: bindinng -> binding

### DIFF
--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -51,7 +51,7 @@ storageClass:
   # Set access mode - ReadWriteOnce, ReadOnlyMany or ReadWriteMany
   accessModes: ReadWriteOnce
 
-  # Set volume bindinng mode - Immediate or WaitForFirstConsumer
+  # Set volume binding mode - Immediate or WaitForFirstConsumer
   volumeBindingMode: Immediate
 
   # Storage class annotations


### PR DESCRIPTION
Seems there is a small typo in the values yaml. This fixes that