### PR TITLE
docs: add changelog for v4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v4.0.3
+
+- Prevent mounting of root directory on empty customPath (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/83)
+- Upgrade k8s client to v1.23.4 (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/175)
+- Add error handling to chmod on volume creation (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/176)
+- Import GetPersistentVolumeClass from component-helpers (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/189)
+- Resolve CVE-2022-27191 in golang.org/x/crypto (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/207)
+- Fix onDelete option for subdirectories (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/221)
+- Resolve all trivy vulnerabilities up to 2024-01-25 (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/327)
+
 # v4.0.2
 - Add arm7 (32bit) support (https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/58)
 


### PR DESCRIPTION
Look's like we are ready for v4.0.3, here is the changelog. 
The version can be tested with image: `quay.io/yonatankahana/nfs-subdir-external-provisioner:v4.0.3-rc2`. 
For helm use: `--set image.repository=quay.io/yonatankahana/nfs-subdir-external-provisioner,image.tag=v4.0.3-rc2`

quay.io [report](https://quay.io/repository/yonatankahana/nfs-subdir-external-provisioner/manifest/sha256:bd955a6b9b64a1c53f59cf070c592e208ec35e83a29aedd899cb10f2a2b9c684?tab=vulnerabilities) and Trivy report:

```
$ trivy image quay.io/yonatankahana/nfs-subdir-external-provisioner:v4.0.3-rc2
quay.io/yonatankahana/nfs-subdir-external-provisioner:v4.0.3-rc2 (debian 11.8)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

@kmova - let's release it

/assign @kmova 