### PR TITLE
Add topologySpreadConstraints and skew to evenly distribute pods across multiple nodes

### DIFF
--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -23,6 +23,15 @@ spec:
       labels:
         {{- include "nfs-subdir-external-provisioner.podLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.skew }}
+      topologySpreadConstraints:
+      - maxSkew: {{ .Values.skew.maxSkew }}
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: {{ .Values.skew.whenUnsatisfiable }}
+        labelSelector:
+          matchLabels:
+            app: {{ template "nfs-subdir-external-provisioner.fullname" . }}
+      {{- end }}
       serviceAccountName: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -15,6 +15,10 @@ nfs:
   # Reclaim policy for the main nfs volume
   reclaimPolicy: Retain
 
+skew:
+  maxSkew: 1
+  whenUnsatisfiable: ScheduleAnyway
+
 # For creating the StorageClass automatically:
 storageClass:
   create: true


### PR DESCRIPTION
Added `topologySpreadConstraints` to the deployment chart and the default values in order to evenly distribute pods accross HA cluster nodes