### PR TITLE
Update container version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 The Kubernetes Authors.
+# Copyright 2023 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.18 as build-env
+FROM --platform=$BUILDPLATFORM golang:1.19 as build-env
 
 # xx wraps go to automatically configure $GOOS, $GOARCH, and $GOARM
 # based on TARGETPLATFORM provided by Docker.
@@ -13,7 +13,7 @@ WORKDIR ${APP_FOLDER}
 ARG TARGETPLATFORM
 RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /bin/main ./cmd/nfs-subdir-external-provisioner
 
-FROM --platform=$TARGETPLATFORM alpine:3.12
+FROM --platform=$TARGETPLATFORM alpine:3.18
 
 RUN apk update --no-cache && apk add ca-certificates
 COPY --from=build-env /bin/main /app/main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/nfs-subdir-external-provisioner
 
-go 1.17
+go 1.19
 
 require (
 	github.com/golang/glog v1.0.0


### PR DESCRIPTION
- Update multiarch build container to use golang:1.19 as the project is tested on 1.19
- Update the multiarch container to run Alpine 3.18
  Updating to this version reduces the number of known vulnerabilities in the image
- Update go.mod to match the container version
