### PR TITLE
Provide existing ConfigMap for nfs configuration

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -11,3 +11,4 @@ keywords:
 - nfs
 - storage
 - provisioner
+ 

--- a/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
+++ b/charts/nfs-subdir-external-provisioner/templates/_helpers.tpl
@@ -1,3 +1,11 @@
+
+{{/* 
+   Allow namespace to be overriden
+*/}}
+{{- define "common.names.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
@@ -101,3 +109,50 @@ Selector labels
 app: {{ template "nfs-subdir-external-provisioner.name" . }}
 release: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Return true if an existing configmap name has been provided 
+*/}}
+{{- define "nfs.existing-configmap-provided" -}}
+{{- if  .Values.nfs.existingConfigMap.name -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the existing NFS Configmap Name
+*/}}
+{{- define "nfs.existing-configmap" -}}
+     {{- if .Values.nfs.existingConfigMap.name -}}
+         {{- printf "%s" (tpl .Values.nfs.existingConfigMap.name $) -}}
+     {{- else -}}
+         {{- printf "\n%s CONFIGMAP ERROR: no existing configmap has been provided" }}
+     {{- end -}}
+{{- end }}
+
+
+{{/*
+Reuses the value from an existing configmap, otherwise sets its value to a default value.
+
+Usage:
+{{ include "common.configmap.lookup" (dict "secret" "configmap-name" "key" "keyName" "defaultValue" .Values.myValue "context" $) }}
+
+Params:
+  - config - String - Required - Name of the 'Secret' resource where the password is stored.
+  - key - String - Required - Name of the key in the secret.
+  - defaultValue - String - Required - The path to the validating value in the values.yaml, e.g: "mysql.password". Will pick first parameter with a defined value.
+  - context - Context - Required - Parent context.
+
+*/}}
+{{- define "common.configmap.lookup" -}}
+{{- $value := "" -}}
+{{- $configmapData := (lookup "v1" "ConfigMap" .context.Values.nfs.existingConfigMap.namespace .config).data -}}
+{{- if and $configmapData (hasKey $configmapData .key) -}}
+  {{- $value = index $configmapData .key -}}
+{{- else if .defaultValue -}}
+  {{- $value = .defaultValue | toString  -}}
+{{- end -}}
+{{- if $value -}}
+{{- printf "%s" $value -}}
+{{- end -}}
+{{- end -}}

--- a/charts/nfs-subdir-external-provisioner/templates/configmap.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- $server := .Values.nfs.server  | default "127.0.0.1" -}}
+{{ if (include "nfs.existing-configmap-provided" .) }}
+{{- $existingConfigMap := (lookup "v1" "ConfigMap" .Values.nfs.existingConfigMap.namespace .Values.nfs.existingConfigMap.name).data }}
+{{- if (not $existingConfigMap)  }}
+apiVersion: v1
+data:
+  path: {{ .Values.nfs.path }}
+  server: {{ $server }}
+immutable: false
+kind: ConfigMap
+metadata:
+  name: {{ template "nfs.existing-configmap" . }}
+  annotation: 
+    helm.sh/hook: pre-install, pre-upgrade
+{{- end }}
+{{- end }}

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- $server := .Values.nfs.server | default "127.0.0.1" -}}
+{{- $path := .Values.nfs.path -}}
+{{- if (include "nfs.existing-configmap-provided" .) -}}
+{{- $server = (include "common.configmap.lookup" (dict "config" .Values.nfs.existingConfigMap.name "key" "server" "defaultValue" "127.0.0.1" "context" $)) -}}
+{{- $path = (include "common.configmap.lookup" (dict "config" .Values.nfs.existingConfigMap.name "key" "path" "defaultValue" .Values.nfs.path "context" $)) -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,9 +60,9 @@ spec:
             - name: PROVISIONER_NAME
               value: {{ template "nfs-subdir-external-provisioner.provisionerName" . }}
             - name: NFS_SERVER
-              value: {{ .Values.nfs.server }}
+              value: {{ $server }}
             - name: NFS_PATH
-              value: {{ .Values.nfs.path }}
+              value: {{ $path }}
             {{- if eq .Values.leaderElection.enabled false }}
             - name: ENABLE_LEADER_ELECTION
               value: "false"
@@ -74,8 +80,8 @@ spec:
             claimName: pvc-{{ template "nfs-subdir-external-provisioner.fullname" . }}
 {{- else }}
           nfs:
-            server: {{ .Values.nfs.server }}
-            path: {{ .Values.nfs.path }}
+            server: {{ $server}}
+            path: {{ $path }}
 {{- end }}
       {{- if and (.Values.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
       tolerations:

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
@@ -1,4 +1,10 @@
 {{ if .Values.nfs.mountOptions -}}
+{{- $server := .Values.nfs.server -}}
+{{- $path := .Values.nfs.path -}}
+{{- if (include "nfs.existing-configmap-provided" .) -}}
+{{- $server := (include "common.configmap.lookup" (dict "config" .Values.nfs.existingConfigMap.name "key" "server" "defaultValue" .Values.nfs.server "context" $)) -}}
+{{- $path := (include "common.configmap.lookup" (dict "config" .Values.nfs.existingConfigMap.name "key" "path" "defaultValue" .Values.nfs.path "context" $)) -}}
+{{- end -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -21,6 +27,6 @@ spec:
     {{- end }}
   {{- end }}
   nfs:
-    server: {{ .Values.nfs.server }}
-    path: {{ .Values.nfs.path }}
+    server: {{ $server }}
+    path: {{ $path }}
 {{ end -}}

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -14,6 +14,10 @@ nfs:
   volumeName: nfs-subdir-external-provisioner-root
   # Reclaim policy for the main nfs volume
   reclaimPolicy: Retain
+  # existing configmap in order to get server and path
+  existingConfigMap:
+    name: oiadp-nfs-config
+    namespace: default
 
 # For creating the StorageClass automatically:
 storageClass:


### PR DESCRIPTION
Provide existing ConfigMap for nfs configuration, if the existingConfigMap name is provided but still doesn't exist in the cluster it will be created with params defined in Values.yaml.

Why we need these changes? 
One of the customer that I work with have an existing NFS server in a on prem infrastructure and they need to use that for storing backup dump files. The Kubernetes cluster in this case is not hosted in cloud and it's created with a complex Terraform script that already create configMaps and secrets for all the applications installable in that cluster. They asked me to use nfs-subdir-external-provisioner chart in order to include that as a subChart in an other chart. The needs is to give to nfs-provisioner subChart the existing configMap created by the terraform script so it can lookup and grab server and path configuration value for that specific cluster. I think it's a common scenario for different usage and it's not different from many bitnami charts like postgresql that allow us to give existing secrets to configure postgresql application. I thought it would be appropriate give my contribution to the community but feel free to change or reject my PR if it's not compliant to the repository rules.
Thanks in advance .
Andrea Pulvirenti