### PR TITLE
Fix PV path determination on deletion

### DIFF
--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -146,7 +146,7 @@ func (p *nfsProvisioner) Provision(ctx context.Context, options controller.Provi
 func (p *nfsProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {
 	path := volume.Spec.PersistentVolumeSource.NFS.Path
 	basePath := filepath.Base(path)
-	oldPath := strings.Replace(path, p.path, mountPath, 1)
+	oldPath := filepath.Join(mountPath, strings.Replace(path, p.path, "", 1))
 
 	if _, err := os.Stat(oldPath); os.IsNotExist(err) {
 		glog.Warningf("path %s does not exist, deletion skipped", oldPath)


### PR DESCRIPTION
Determination of `oldPath` in Delete func seems to be broken. With my test pvc, I get following vars prior to path calculation:
```
	path := "/var/nfsshare/vms/default/test-claim-1"
	p_dot_path := "/var/nfsshare/vms/"
	mountPath := "/persistentvolumes"
```
For the above vars, current implementation leads to `/persistentvolumesdefault/test-claim-1` being generated instead of `/persistentvolumes/default/test-claim-1`. This PR fixes the issue by using filepath.Join instead of using  strings.Replace exclusively.