### PR TITLE
add missing namespace

### DIFF
--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvc-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:

--- a/charts/nfs-subdir-external-provisioner/templates/poddisruptionbudget.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/poddisruptionbudget.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | default 1 }}
   selector:

--- a/charts/nfs-subdir-external-provisioner/templates/role.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/role.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}

--- a/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
Adding missing namespace to helm chart.

Helm did render all manifests without a namespace resulting in invalid manifests (missing namespace) errors in ArgoCD. 
This prevented ArgoCD from deploying the resources on the cluster. I had to render it locally and add the namespace manually. 

With this change, all manifests get rendered correctly with the namespace set. 
this change would allow us to deploy and use the Helm chart with Kustomize via ArgoCD.

Test with `helm template my-nfs-provisioner-test -n nfs-storage-example .`

