### PR TITLE
Adding .Release.Namespace

### DIFF
--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: pv-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: 
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
     nfs-subdir-external-provisioner: {{ template "nfs-subdir-external-provisioner.fullname" . }}

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvc-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:

--- a/charts/nfs-subdir-external-provisioner/templates/poddisruptionbudget.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/poddisruptionbudget.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable | default 1 }}
   selector:

--- a/charts/nfs-subdir-external-provisioner/templates/podsecuritypolicy.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
 spec:

--- a/charts/nfs-subdir-external-provisioner/templates/role.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/role.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/rolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
   name: leader-locking-{{ template "nfs-subdir-external-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}

--- a/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ template "nfs-subdir-external-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
I was finding that while installing this chart with terraform helm_release it would place the resources in whatever my kube_config had defined by default rather than the actual namespace specified by the chart, it seems to be due to missing explicit namespace specifications on the part of the chart.