### PR TITLE
fix: remove namespace from PersistentVolume

### DIFF
--- a/charts/nfs-subdir-external-provisioner/Chart.yaml
+++ b/charts/nfs-subdir-external-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 4.0.2
 description: nfs-subdir-external-provisioner is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-subdir-external-provisioner
 home: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner
-version: 4.0.18
+version: 4.0.19
 kubeVersion: ">=1.9.0-0"
 sources:
 - https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner

--- a/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/persistentvolume.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: pv-{{ template "nfs-subdir-external-provisioner.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels: 
+  labels:
     {{- include "nfs-subdir-external-provisioner.labels" . | nindent 4 }}
     nfs-subdir-external-provisioner: {{ template "nfs-subdir-external-provisioner.fullname" . }}
 spec:


### PR DESCRIPTION
follow up to https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/368 