### PR TITLE
Fix special bit handling in default mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ spec:
 
 **Step 8: Controlling the permissions and ownership of subdirs**
 
-By default new directories will be created with `root:root` ownership, and `0777` permissions in most environments. If you have a need to control this, you can do so by providing the `NFS_DEFAULT_MODE`, `NFS_DEFAULT_UID` and `NFS_DEFAULT_GID` environment variables (or the appropriate configuration in the Helm chart values). The mode must be an octal representation of a file mode, for example `777`, `0755` etc. The uid and gid must be the numeric ids of your desired user and group, so `1000` not `my_user`. 
+By default new directories will be created with `root:root` ownership, and `0777` permissions in most environments. If you have a need to control this, you can do so by providing the `NFS_DEFAULT_MODE`, `NFS_DEFAULT_UID` and `NFS_DEFAULT_GID` environment variables (or the appropriate configuration in the Helm chart values). The mode must be an octal representation of a file mode, for example `777`, `0755`, `2750` etc. The uid and gid must be the numeric ids of your desired user and group, so `1000` not `my_user`. 
 
 If your usecase requires per-PVC ownership and/or mode, this can be done via annotations on your PVC:
 

--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -258,10 +258,20 @@ func getModeFromString(mode string) (os.FileMode, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid mode %s: %v", mode, err)
 	}
-	if modeInt < 0 || modeInt > 0o777 {
-		return 0, fmt.Errorf("mode must be between 0 and 0777, got %s", mode)
+	if modeInt < 0 || modeInt > 0o7777 {
+		return 0, fmt.Errorf("mode must be between 0 and 07777, got %s", mode)
 	}
-	return os.FileMode(modeInt), nil
+	fileMode := os.FileMode(modeInt & 0o777)
+	if modeInt&0o4000 != 0 {
+		fileMode |= os.ModeSetuid
+	}
+	if modeInt&0o2000 != 0 {
+		fileMode |= os.ModeSetgid
+	}
+	if modeInt&0o1000 != 0 {
+		fileMode |= os.ModeSticky
+	}
+	return fileMode, nil
 }
 
 func getIdFromString(id string) (int, error) {


### PR DESCRIPTION
Currently, setting the special bits (sticky, setuid, setgid) in the default mode (ie the `2` in `2775`, say) is *not* supported and will error. There is a gate that is only allowing for the user/group/other bits (the `775`) and errors if you provide the special one.

Additionally, even without that gate, os.FileMode's handling of the special bits need some special handling to actually set the special bits correctly from an integer representation.

This PR fixes the gate's mask to allow for the special bits, as well as parses the int to set os.FileMode's output correctly.