### PR TITLE
Add configurable leader election timing via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,18 @@ spec:
 
 Note: If you want to change the PROVISIONER_NAME above from `k8s-sigs.io/nfs-subdir-external-provisioner` to something else like `myorg/nfs-storage`, remember to also change the PROVISIONER_NAME in the storage class definition below.
 
-To disable leader election, define an env variable named ENABLE_LEADER_ELECTION and set its value to false.
+**Leader election configuration:**
+
+The provisioner supports leader election to ensure only one replica is active at a time. The following environment variables configure leader election:
+
+| Env Variable | Default | Description |
+|-------------|---------|-------------|
+| `ENABLE_LEADER_ELECTION` | `true` | Set to `"false"` to disable leader election entirely. |
+| `LEADER_ELECTION_LEASE_DURATION` | `15s` | Time that non-leader candidates wait before attempting to acquire leadership. Must be greater than renew deadline. |
+| `LEADER_ELECTION_RENEW_DEADLINE` | `10s` | Time the current leader will retry refreshing leadership before giving up. Must be greater than retry period. |
+| `LEADER_ELECTION_RETRY_PERIOD` | `2s` | Interval between leadership renewal attempts. |
+
+> **Tuning for large clusters:** If you experience leader election timeouts due to etcd compaction or API server latency spikes, increase `LEADER_ELECTION_RENEW_DEADLINE` (e.g., `30s` or `60s`) and adjust `LEADER_ELECTION_RETRY_PERIOD` proportionally. Both `renewDeadline > retryPeriod` and `leaseDuration > renewDeadline` must hold.
 
 **Step 5: Deploying your storage class**
 

--- a/charts/nfs-subdir-external-provisioner/README.md
+++ b/charts/nfs-subdir-external-provisioner/README.md
@@ -68,6 +68,9 @@ The following tables lists the configurable parameters of this chart and their d
 | `storageClass.volumeBindingMode`     | Set volume binding mode for Storage Class                                                             | `Immediate`                                                   |
 | `storageClass.annotations`           | Set additional annotations for the StorageClass                                                       | `{}`                                                          |
 | `leaderElection.enabled`             | Enables or disables leader election                                                                   | `true`                                                        |
+| `leaderElection.leaseDuration`       | Leader election lease duration                                                                        | `15s`                                                         |
+| `leaderElection.renewDeadline`       | Leader election renew deadline                                                                        | `10s`                                                         |
+| `leaderElection.retryPeriod`         | Leader election retry period                                                                          | `2s`                                                          |
 | `nfs.server`                         | Hostname of the NFS server (required)                                                                 | null (ip or hostname)                                         |
 | `nfs.path`                           | Basepath of the mount point to be used                                                                | `/nfs-storage`                                                |
 | `nfs.mountOptions`                   | Mount options (e.g. 'nfsvers=3')                                                                      | null                                                          |

--- a/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
+++ b/charts/nfs-subdir-external-provisioner/templates/deployment.yaml
@@ -64,7 +64,14 @@ spec:
               value: {{ .Values.nfs.defaultUid }}
             - name: NFS_DEFAULT_GID
               value: {{ .Values.nfs.defaultGid }}
-            {{- if eq .Values.leaderElection.enabled false }}
+            {{- if ne .Values.leaderElection.enabled false }}
+            - name: LEADER_ELECTION_LEASE_DURATION
+              value: {{ .Values.leaderElection.leaseDuration | quote }}
+            - name: LEADER_ELECTION_RENEW_DEADLINE
+              value: {{ .Values.leaderElection.renewDeadline | quote }}
+            - name: LEADER_ELECTION_RETRY_PERIOD
+              value: {{ .Values.leaderElection.retryPeriod | quote }}
+            {{- else }}
             - name: ENABLE_LEADER_ELECTION
               value: "false"
             {{- end }}

--- a/charts/nfs-subdir-external-provisioner/values.yaml
+++ b/charts/nfs-subdir-external-provisioner/values.yaml
@@ -64,6 +64,15 @@ leaderElection:
   # When set to false leader election will be disabled
   enabled: true
 
+  # Leader election lease duration. Must be greater than renewDeadline.
+  leaseDuration: 15s
+
+  # Leader election renew deadline. Must be greater than retryPeriod.
+  renewDeadline: 10s
+
+  # Leader election retry period.
+  retryPeriod: 2s
+
 ## For RBAC support:
 rbac:
   # Specifies whether RBAC resources should be created

--- a/cmd/nfs-subdir-external-provisioner/provisioner.go
+++ b/cmd/nfs-subdir-external-provisioner/provisioner.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
@@ -347,6 +348,56 @@ func main() {
 		}
 	}
 
+	options := []func(*controller.ProvisionController) error{
+		controller.LeaderElection(leaderElection),
+	}
+
+	if leaderElection {
+		leaseDuration := controller.DefaultLeaseDuration
+		renewDeadline := controller.DefaultRenewDeadline
+		retryPeriod := controller.DefaultRetryPeriod
+
+		if v := os.Getenv("LEADER_ELECTION_LEASE_DURATION"); v != "" {
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				glog.Fatalf("Unable to parse LEADER_ELECTION_LEASE_DURATION env var: %v", err)
+			}
+			leaseDuration = d
+		}
+		if v := os.Getenv("LEADER_ELECTION_RENEW_DEADLINE"); v != "" {
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				glog.Fatalf("Unable to parse LEADER_ELECTION_RENEW_DEADLINE env var: %v", err)
+			}
+			renewDeadline = d
+		}
+		if v := os.Getenv("LEADER_ELECTION_RETRY_PERIOD"); v != "" {
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				glog.Fatalf("Unable to parse LEADER_ELECTION_RETRY_PERIOD env var: %v", err)
+			}
+			retryPeriod = d
+		}
+
+		options = append(options,
+			controller.LeaseDuration(leaseDuration),
+			controller.RenewDeadline(renewDeadline),
+			controller.RetryPeriod(retryPeriod),
+		)
+
+		if leaseDuration <= renewDeadline {
+			glog.Fatalf("LEADER_ELECTION_LEASE_DURATION (%v) must be greater than LEADER_ELECTION_RENEW_DEADLINE (%v)",
+				leaseDuration, renewDeadline)
+		}
+		if renewDeadline <= retryPeriod {
+			glog.Fatalf("LEADER_ELECTION_RENEW_DEADLINE (%v) must be greater than LEADER_ELECTION_RETRY_PERIOD (%v)",
+				renewDeadline, retryPeriod)
+		}
+
+		glog.Infof("leader election: leaseDuration=%v renewDeadline=%v retryPeriod=%v",
+			leaseDuration, renewDeadline, retryPeriod)
+	}
+
 	clientNFSProvisioner := &nfsProvisioner{
 		client:      clientset,
 		server:      server,
@@ -361,7 +412,7 @@ func main() {
 		provisionerName,
 		clientNFSProvisioner,
 		serverVersion.GitVersion,
-		controller.LeaderElection(leaderElection),
+		options...,
 	)
 	// Never stops.
 	pc.Run(context.Background())

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -32,6 +32,12 @@ spec:
               value: 10.3.243.101
             - name: NFS_PATH
               value: /ifs/kubernetes
+            - name: LEADER_ELECTION_LEASE_DURATION
+              value: "15s"
+            - name: LEADER_ELECTION_RENEW_DEADLINE
+              value: "10s"
+            - name: LEADER_ELECTION_RETRY_PERIOD
+              value: "2s"
       volumes:
         - name: nfs-client-root
           nfs:


### PR DESCRIPTION
  ## What
    
    Add three environment variables to configure leader election timing parameters:
    
    - `LEADER_ELECTION_LEASE_DURATION` (default: `15s`)
    - `LEADER_ELECTION_RENEW_DEADLINE` (default: `10s`)
    - `LEADER_ELECTION_RETRY_PERIOD` (default: `2s`)
    
  ## Why
    
    In large clusters, etcd compaction can cause API server latency spikes. The default renew deadline of 10s with a 2s retry interval mea
    ns the leader gives up after 5 consecutive failures and the container restarts. These new environment variables allow operators to inc
    rease the tolerance for transient API server slowdowns without modifying code or rebuilding images.
    
  ## Changes
    
    - `provisioner.go`: read env vars inside the leader election block, validate `leaseDuration > renewDeadline > retryPeriod`, log final 
    values
    - `charts/.../values.yaml`: expose `leaderElection.leaseDuration` / `.renewDeadline` / `.retryPeriod`
    - `charts/.../templates/deployment.yaml`: inject env vars when leader election is enabled
    - `deploy/deployment.yaml`: document new env vars with default values in example deployment
    - `README.md` + `charts/.../README.md`: add configuration tables
    
    All changes are backward-compatible — defaults match the existing behavior exactly.