### PR TITLE
cloudbuild: bump gcb-docker-gcloud to v20260205-38cfa9523f

### DIFF
--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2' # v20260205-38cfa9523f
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
The nfs-subdir-external-provisioner push-images job has been failing
because release-tools/cloudbuild.yaml pins
gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55,
and that tag has been garbage-collected from the staging registry.
Cloud Build retries the pull 10 times and fails with:

  manifest unknown: Failed to fetch "v20210917-12df099d55"

Bumping to v20260205-38cfa9523f (digest
sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2),
currently the newest tag in gcr.io/k8s-staging-test-infra/gcb-docker-gcloud.

/kind failing-test

Which issue(s) this PR fixes:
Fixes kubernetes/kubernetes#138936

Does this PR introduce a user-facing change?:
NONE